### PR TITLE
move TODO item to correct heading

### DIFF
--- a/lang/values.md
+++ b/lang/values.md
@@ -113,8 +113,6 @@ and having int-to-ptr transmutation generate "invalid" pointers (like [`ptr::inv
 This is required to achieve a "monotonicity" with respect to provenance (as discussed [below](#generic-properties)).
 
 - TODO: Is that the right semantics for ptr-to-int transmutation? See [this discussion](https://github.com/rust-lang/unsafe-code-guidelines/issues/286).
-- TODO: This definition says that when multiple provenances are mixed, the pointer has `None` provenance, i.e., it is "invalid".
-  Is that the semantics we want? Also see [this discussion](https://github.com/rust-lang/unsafe-code-guidelines/issues/286#issuecomment-1136948796).
 - TODO: This does not allow uninitialized integers. I think that is fairly clearly what we want, also considering LLVM is moving towards using `noundef` heavily to avoid many of the current issues in their `undef` handling. But this is also still [being discussed](https://github.com/rust-lang/unsafe-code-guidelines/issues/71).
 
 ### Raw pointers
@@ -154,6 +152,9 @@ impl Type {
     }
 }
 ```
+
+- TODO: This definition says that when multiple provenances are mixed, the pointer has `None` provenance, i.e., it is "invalid".
+  Is that the semantics we want? Also see [this discussion](https://github.com/rust-lang/unsafe-code-guidelines/issues/286#issuecomment-1136948796).
 
 ### References and `Box`
 


### PR DESCRIPTION
I think this TODO was misplaced, under integers instead of pointers. This was confusing to me for a while!