### PR TITLE
Experimental sum-like union representation.

### DIFF
--- a/lang/types.md
+++ b/lang/types.md
@@ -56,13 +56,8 @@ enum Type {
     Union {
         /// Fields *may* overlap. Fields only exist for field access place projections,
         /// they are irrelevant for the representation relation.
-        fields: Fields,
-        /// A union can be split into multiple "chunks", where only the data inside those chunks is
-        /// preserved, and data between chunks is lost (like padding in a struct).
-        /// This is necessary to model the behavior of some `repr(C)` unions, see
-        /// <https://github.com/rust-lang/unsafe-code-guidelines/issues/156> for details.
-        chunks: List<(Size, Size)>, // (offset, length) for each chunk.
-        /// The total size of the union, can indicate padding after the last chunk.
+        fields: Fields
+        /// The total size of the union, can indicate padding after all fields.
         size: Size,
     },
     Enum {
@@ -126,7 +121,7 @@ impl Type {
             Ref { pointee, .. } | Box { pointee } => pointee.inhabited,
             Tuple { fields, .. } => fields.iter().all(|type| type.inhabited()),
             Array { elem, count } => count == 0 || elem.inhabited(),
-            Union { .. } => true,
+            Union { .. } => fields.iter().any(|type| type.inhabited()),
             Enum { variants, .. } => variants.iter().any(|type| type.inhabited()),
         }
     }


### PR DESCRIPTION
This is a counterexample, I hope, to @RalfJung's claim that the
representation model of union values needs to be much more elaborate to
take this approach to unions, e.g. in
rust-lang/unsafe-code-guidelines#73.

In this representation, a union is treated as a conceptual sum type,
except that it may actually have one value for each field due to the
lack of discriminant.

When decoding, we attempt to decode all fields. If at least one
succeeds, we consider it a success. This captures the idea that a union
value is valid iff it is valid for at least one field.

When encoding, for every field present, we encode it, and then we
combine those into a single encoding. There is a unique encoding that
will ensure that round-tripping a decode to an encode and back is valid.

The actual definition is quite simple, but it does require relaxing the
round-tripping invariant in the other direction: going to bytes and back
may add information to a union value, because it forces us to compute
which other fields' values can be deduced from the stored value.

I believe that if we get rid of the checks that a union value always has
at least one valid field, we actually recover something quite close to
the current model, except that the field Values are properly encoded in
the union. This might actually be an advantage, because it will make
code dealing with unions and tuples much more similar, for instance in
codegen, rather than being two very different beasts.

Incidentally extends tuple encode/decode to arbitrary sized tuples, in
order to factor out the common code.

Rendered:
[Values](https://github.com/alercah/minirust/blob/value-unions/lang/values.md),
[Types](https://github.com/alercah/minirust/blob/value-unions/lang/types.md)