### PR TITLE
Mostly typo fixes

### DIFF
--- a/lang/operator.md
+++ b/lang/operator.md
@@ -105,7 +105,7 @@ impl Machine {
     /// and the offset must stay in bounds of a single allocation.
     fn ptr_offset_inbounds(&self, ptr: Pointer, offset: BigInt) -> NdResult<Pointer> {
         if !offset.in_bounds(Signed, PTR_SIZE) {
-            throw_ub!("inbounds offset does not fit into `isize`"):
+            throw_ub!("inbounds offset does not fit into `isize`");
         }
         let addr = ptr.addr + offset;
         if !addr.in_bounds(Unsigned, PTR_SIZE) {

--- a/lang/operator.md
+++ b/lang/operator.md
@@ -21,7 +21,7 @@ impl Machine {
             Cast => operand,
         }
     }
-    fn eval_un_op(&mut self, Int(op, int_type): UnOp, operand: Value) -> NdResult<Value> {
+    fn eval_un_op(&mut self, UnOp::Int(op, int_type): UnOp, operand: Value) -> NdResult<Value> {
         let Value::Int(operand) = operand else { panic!("non-integer input to integer operation") };
 
         // Perform the operation.
@@ -37,12 +37,12 @@ impl Machine {
 
 ```rust
 impl Machine {
-    fn eval_un_op(&mut self, Ptr2Int: UnOp, operand: Value) -> NdResult<Value> {
+    fn eval_un_op(&mut self, UnOp::Ptr2Int: UnOp, operand: Value) -> NdResult<Value> {
         let Value::Ptr(ptr) = operand else { panic!("non-pointer input to ptr2int cast") };
         let result = self.intptrcast.ptr2int(ptr)?;
         Value::Int(result)
     }
-    fn eval_un_op(&mut self, Int2Ptr: UnOp, operand: Value) -> NdResult<Value> {
+    fn eval_un_op(&mut self, UnOp::Int2Ptr: UnOp, operand: Value) -> NdResult<Value> {
         let Value::Int(addr) = operand else { panic!("non-integer input to int2ptr cast") };
         let result = self.intptrcast.int2ptr(addr)?;
         Value::Ptr(result)
@@ -76,7 +76,7 @@ impl Machine {
             }
         }
     }
-    fn eval_bin_op(&mut self, Int(op, int_type): BinOp, left: Value, right: Value) -> NdResult<Value> {
+    fn eval_bin_op(&mut self, BinOp::Int(op, int_type): BinOp, left: Value, right: Value) -> NdResult<Value> {
         let Value::Int(left) = left else { panic!("non-integer input to integer operation") };
         let Value::Int(right) = right else { panic!("non-integer input to integer operation") };
 
@@ -129,7 +129,7 @@ impl Machine {
         new_ptr
     }
 
-    fn eval_bin_op(&mut self, PtrOffset { inbounds }: BinOp, left: Value, right: Value) -> NdResult<Value> {
+    fn eval_bin_op(&mut self, BinOp::PtrOffset { inbounds }: BinOp, left: Value, right: Value) -> NdResult<Value> {
         let Value::Ptr(left) = left else { panic!("non-pointer left input to pointer addition") };
         let Value::Int(right) = right else { panic!("non-integer right input to pointer addition") };
 

--- a/lang/prelude.md
+++ b/lang/prelude.md
@@ -4,9 +4,12 @@ For the files in this folder, we assume some definitions and parameters to alway
 
 ```rust
 // An instance of the memory interface.
-use mem::interface::*;
+use crate::mem::interface::*;
 type Memory: MemoryInterface;
-use Memory::{Provenance, Pointer, AbstractByte};
+
+type Provenance = Memory::Provenance;
+type Pointer = Memory::Pointer;
+type AbstractByte = Memory::AbstractByte;
 
 // The endianess, which defines how integers are encoded and decoded.
 trait Endianess {

--- a/lang/prelude.md
+++ b/lang/prelude.md
@@ -7,9 +7,9 @@ For the files in this folder, we assume some definitions and parameters to alway
 use crate::mem::interface::*;
 type Memory: MemoryInterface;
 
-type Provenance = <Memory as MemoryInterface>::Provenance;
-type Pointer = <Memory as MemoryInterface>::Pointer;
-type AbstractByte = <Memory as MemoryInterface>::AbstractByte;
+type Provenance = Memory::Provenance;
+type Pointer = Memory::Pointer;
+type AbstractByte = Memory::AbstractByte;
 
 // The endianess, which defines how integers are encoded and decoded.
 trait Endianess {

--- a/lang/prelude.md
+++ b/lang/prelude.md
@@ -14,11 +14,11 @@ type AbstractByte = Memory::AbstractByte;
 // The endianess, which defines how integers are encoded and decoded.
 trait Endianess {
     /// If `signed == Signed`, the data is interpreted as two's complement.
-    fn decode<N: usize>(self, signed: Signedness, bytes: [u8; N]) -> BigInt;
+    fn decode<const N: usize>(self, signed: Signedness, bytes: [u8; N]) -> BigInt;
 
     /// This can fail (return `None`) if the `int` does not fit into `N` bytes,
     /// or if it is negative and `signed == Unsigned`.
-    fn encode<N: usize>(self, signed: Signedness, int: BigInt) -> Option<[u8; N]>;
+    fn encode<const N: usize>(self, signed: Signedness, int: BigInt) -> Option<[u8; N]>;
 }
 const ENDIANESS: impl Endianess;
 

--- a/lang/prelude.md
+++ b/lang/prelude.md
@@ -7,9 +7,9 @@ For the files in this folder, we assume some definitions and parameters to alway
 use crate::mem::interface::*;
 type Memory: MemoryInterface;
 
-type Provenance = Memory::Provenance;
-type Pointer = Memory::Pointer;
-type AbstractByte = Memory::AbstractByte;
+type Provenance = <Memory as MemoryInterface>::Provenance;
+type Pointer = <Memory as MemoryInterface>::Pointer;
+type AbstractByte = <Memory as MemoryInterface>::AbstractByte;
 
 // The endianess, which defines how integers are encoded and decoded.
 trait Endianess {

--- a/lang/step.md
+++ b/lang/step.md
@@ -50,7 +50,7 @@ Constants are trivial, as one would hope.
 
 ```rust
 impl Machine {
-    fn eval_value(&mut self, Constant(value, _type): ValueExpr) -> NdResult<Value> {
+    fn eval_value(&mut self, ValueExpr::Constant(value, _type): ValueExpr) -> NdResult<Value> {
         value
     }
 }
@@ -62,7 +62,7 @@ This loads a value from a place (often called "place-to-value coercion").
 
 ```rust
 impl Machine {
-    fn eval_value(&mut self, Load { destructive, source }: ValueExpr) -> NdResult<Value> {
+    fn eval_value(&mut self, ValueExpr::Load { destructive, source }: ValueExpr) -> NdResult<Value> {
         let p = self.eval_place(source)?;
         let ptype = source.check(self.cur_frame().func.locals).unwrap();
         let v = self.mem.typed_load(p, ptype)?;
@@ -81,12 +81,12 @@ The `&` operators simply converts a place to the pointer it denotes.
 
 ```rust
 impl Machine {
-    fn eval_value(&mut self, AddrOf { target }: ValueExpr) -> NdResult<Value> {
+    fn eval_value(&mut self, ValueExpr::AddrOf { target }: ValueExpr) -> NdResult<Value> {
         let p = self.eval_place(target)?;
         Value::Ptr(p)
     }
 
-    fn eval_value(&mut self, Ref { target, align, .. }: ValueExpr) -> NdResult<Value> {
+    fn eval_value(&mut self, ValueExpr::Ref { target, align, .. }: ValueExpr) -> NdResult<Value> {
         let p = self.eval_place(target)?;
         let ptype = target.check(self.cur_frame().func.locals).unwrap();
         // We need a check here, to ensure that encoding this value at the given type is valid.
@@ -106,11 +106,11 @@ The functions `eval_un_op` and `eval_bin_op` are defined in [a separate file](op
 
 ```rust
 impl Machine {
-    fn eval_value(&mut self, UnOp { operator, operand }: ValueExpr) -> NdResult<Value> {
+    fn eval_value(&mut self, ValueExpr::UnOp { operator, operand }: ValueExpr) -> NdResult<Value> {
         let operand = self.eval_value(operand)?;
         self.eval_un_op(operator, operand)?
     }
-    fn eval_value(&mut self, BinOp { operator, left, right }: ValueExpr) -> NdResult<Value> {
+    fn eval_value(&mut self, ValueExpr::BinOp { operator, left, right }: ValueExpr) -> NdResult<Value> {
         let left = self.eval_value(left)?;
         let right = self.eval_value(right)?;
         self.eval_bin_op(operator, left, right)?
@@ -138,7 +138,7 @@ The place for a local is directly given by the stack frame.
 
 ```rust
 impl Machine {
-    fn eval_place(&mut self, Local(name): PlaceExpr) -> NdResult<Place> {
+    fn eval_place(&mut self, PlaceExpr::Local(name): PlaceExpr) -> NdResult<Place> {
         // This implicitly asserts that the local is live!
         self.cur_frame().locals[name]
     }
@@ -156,7 +156,7 @@ It also ensures that the pointer is dereferenceable.
 
 ```rust
 impl Machine {
-    fn eval_place(&mut self, Deref { operand, .. }: PlaceExpr) -> NdResult<Place> {
+    fn eval_place(&mut self, PlaceExpr::Deref { operand, .. }: PlaceExpr) -> NdResult<Place> {
         let Value::Ptr(p) = self.eval_value(operand)? else {
             panic!("dereferencing a non-pointer")
         };
@@ -169,26 +169,26 @@ impl Machine {
 
 ```rust
 impl Machine {
-    fn eval_place(&mut self, Field { root, field }: PlaceExpr) -> NdResult<Place> {
+    fn eval_place(&mut self, PlaceExpr::Field { root, field }: PlaceExpr) -> NdResult<Place> {
         let type = root.check(self.cur_frame().func.locals).unwrap().type;
         let root = self.eval_place(root)?;
         let offset = match type {
-            Tuple { fields, .. } => fields[field].0,
-            Union { fields, .. } => fields[field].0,
+            Type::Tuple { fields, .. } => fields[field].0,
+            Type::Union { fields, .. } => fields[field].0,
             _ => panic!("field projection on non-projectable type"),
         };
         assert!(offset < type.size());
         self.ptr_offset_inbounds(root, offset.bytes())?
     }
 
-    fn eval_place(&mut self, Index { root, index }: PlaceExpr) -> NdResult<Place> {
+    fn eval_place(&mut self, PlaceExpr::Index { root, index }: PlaceExpr) -> NdResult<Place> {
         let type = root.check(self.cur_frame().func.locals).unwrap().type;
         let root = self.eval_place(root)?;
         let Value::Int(index) = self.eval_value(index)? else {
             panic!("non-integer operand for array index")
         };
         let offset = match type {
-            Array { elem, count } => {
+            Type::Array { elem, count } => {
                 if index < count {
                     index * elem.size()
                 } else {
@@ -227,7 +227,7 @@ Assignment evaluates its two operands, and then stores the value into the destin
 
 ```rust
 impl Machine {
-    fn eval_statement(&mut self, Assign { destination, source }: Statement) -> NdResult {
+    fn eval_statement(&mut self, Statement::Assign { destination, source }: Statement) -> NdResult {
         let place = self.eval_place(destination)?;
         let val = self.eval_value(source)?;
         let ptype = place.check(self.cur_frame().func.locals).unwrap();
@@ -248,7 +248,7 @@ This is equivalent to the assignment `_ = place`.
 
 ```rust
 impl Machine {
-    fn eval_statement(&mut self, Finalize { place }: Statement) -> NdResult {
+    fn eval_statement(&mut self, Statement::Finalize { place }: Statement) -> NdResult {
         let p = self.eval_place(place)?;
         let ptype = place.check(self.cur_frame().func.locals).unwrap();
         let _val = self.mem.typed_load(p, ptype)?;
@@ -262,14 +262,14 @@ These operations (de)allocate the memory backing a local.
 
 ```rust
 impl Machine {
-    fn eval_statement(&mut self, StorageLive(local): Statement) -> NdResult {
+    fn eval_statement(&mut self, Statement::StorageLive(local): Statement) -> NdResult {
         // Here we make it a spec bug to ever mark an already live local as live.
         let layout = self.cur_frame().func.locals[local].layout();
         let p = self.mem.allocate(layout.size, layout.align)?;
         self.cur_frame_mut().locals.try_insert(local, p).unwrap();
     }
 
-    fn eval_statement(&mut self, StorageDead(local): Statement) -> NdResult {
+    fn eval_statement(&mut self, Statement::StorageDead(local): Statement) -> NdResult {
         // Here we make it a spec bug to ever mark an already dead local as dead.
         let layout = self.cur_frame().func.locals[local].layout();
         let p = self.cur_frame_mut().locals.remove(local).unwrap();
@@ -292,7 +292,7 @@ The simplest terminator: jump to the (beginning of the) given block.
 
 ```rust
 impl Machine {
-    fn eval_terminator(&mut self, Goto(block_name): Terminator) -> NdResult {
+    fn eval_terminator(&mut self, Terminator::Goto(block_name): Terminator) -> NdResult {
         self.cur_frame_mut().next = (block_name, 0);
     }
 }
@@ -302,7 +302,7 @@ impl Machine {
 
 ```rust
 impl Machine {
-    fn eval_terminator(&mut self, If { condition, then_block, else_block }: Terminator) -> NdResult {
+    fn eval_terminator(&mut self, Terminator::If { condition, then_block, else_block }: Terminator) -> NdResult {
         let Value::Bool(b) = self.eval_value(condition)? else {
             panic!("if on a non-boolean")
         };
@@ -316,7 +316,7 @@ impl Machine {
 
 ```rust
 impl Machine {
-    fn eval_terminator(&mut self, Unreachable: Terminator) -> NdResult {
+    fn eval_terminator(&mut self, Terminator::Unreachable: Terminator) -> NdResult {
         throw_ub!("reached unreachable code");
     }
 }
@@ -333,7 +333,7 @@ In particular, we have to initialize the new stack frame.
 impl Machine {
     fn eval_terminator(
         &mut self,
-        Call { callee, arguments, ret, next_block }: Terminator
+        Terminator::Call { callee, arguments, ret, next_block }: Terminator
     ) -> NdResult {
         let Some(func) = self.prog.functions.get(callee) else {
             throw_ub!("calling non-existing function");
@@ -400,7 +400,7 @@ The callee should probably start with a bunch of `Finalize` statements to ensure
 
 ```rust
 impl Machine {
-    fn eval_terminator(&mut self, Return: Terminator) -> NdResult {
+    fn eval_terminator(&mut self, Terminator::Return: Terminator) -> NdResult {
         let frame = self.stack.pop().unwrap();
         let func = frame.func;
         // Copy return value to where the caller wants it.

--- a/lang/syntax.md
+++ b/lang/syntax.md
@@ -84,7 +84,7 @@ enum Terminator {
         ret: (PlaceExpr, ArgAbi),
         /// The block to jump to when this call returns.
         next_block: BbName,
-    }
+    },
     /// Return from the current function.
     Return,
 }

--- a/lang/syntax.md
+++ b/lang/syntax.md
@@ -65,7 +65,7 @@ enum Statement {
 
 enum Terminator {
     /// Just jump to the next block.
-    Goto(BasicBlock),
+    Goto(BbName),
     /// `condition` must evaluate to a `Value::Bool`.
     /// If it is `true`, jump to `then_block`; else jump to `else_block`.
     If {

--- a/lang/types.md
+++ b/lang/types.md
@@ -52,7 +52,7 @@ enum Type {
     Array {
         elem: Type,
         count: BigInt,
-    }
+    },
     Union {
         /// Fields *may* overlap. Fields only exist for field access place projections,
         /// they are irrelevant for the representation relation.

--- a/lang/types.md
+++ b/lang/types.md
@@ -112,22 +112,22 @@ Here we define how to compute the size and other layout properties of a type.
 impl Type {
     fn size(self) -> Size {
         match self {
-            Int(int_type) => int_type.size,
-            Bool => Size::from_bytes(1).unwrap(),
-            Ref { .. } | Box { .. } | RawPtr { .. } => PTR_SIZE,
-            Tuple { size, .. } | Union { size, .. } | Enum { size, .. } => size,
-            Array { elem, count } => elem.size() * count,
+            Type::Int(int_type) => int_type.size,
+            Type::Bool => Size::from_bytes(1).unwrap(),
+            Type::Ref { .. } | Type::Box { .. } | Type::RawPtr { .. } => PTR_SIZE,
+            Type::Tuple { size, .. } | Type::Union { size, .. } | Type::Enum { size, .. } => size,
+            Type::Array { elem, count } => elem.size() * count,
         }
     }
 
     fn inhabited(self) -> bool {
         match self {
-            Int(..) | Bool | RawPtr { .. } => true,
-            Ref { pointee, .. } | Box { pointee } => pointee.inhabited,
-            Tuple { fields, .. } => fields.iter().all(|type| type.inhabited()),
-            Array { elem, count } => count == 0 || elem.inhabited(),
-            Union { .. } => true,
-            Enum { variants, .. } => variants.iter().any(|type| type.inhabited()),
+            Type::Int(..) | Type::Bool | Type::RawPtr { .. } => true,
+            Type::Ref { pointee, .. } | Type::Box { pointee } => pointee.inhabited,
+            Type::Tuple { fields, .. } => fields.iter().all(|type| type.inhabited()),
+            Type::Array { elem, count } => count == 0 || elem.inhabited(),
+            Type::Union { .. } => true,
+            Type::Enum { variants, .. } => variants.iter().any(|type| type.inhabited()),
         }
     }
 }

--- a/lang/values.md
+++ b/lang/values.md
@@ -377,7 +377,7 @@ One key use of the value representation is to define a "typed" interface to memo
 This interface is inspired by [Cerberus](https://www.cl.cam.ac.uk/~pes20/cerberus/).
 
 ```rust
-trait TypedMemory: Memory {
+trait TypedMemory: MemoryInterface {
     /// Write a value of the given type to memory.
     /// Note that it is a spec bug if `val` cannot be encoded at `ty`!
     fn typed_store(&mut self, ptr: Self::Pointer, val: Value, pty: PlaceType) -> Result {

--- a/lang/values.md
+++ b/lang/values.md
@@ -322,7 +322,7 @@ impl PartialOrd for Value {
             (Value::Tuple(vals1), Value::Tuple(vals2)) =>
                 vals1 <= vals2,
             (Value::Variant { idx: idx1, data: data1 }, Value::Variant { idx: idx2, data: data2 }) =>
-                idx == idx1 && data1 <= data2,
+                idx1 == idx2 && data1 <= data2,
             (Value::Union(chunks1), Value::Union(chunks2)) => chunks1 <= chunks2,
             _ => false
         }

--- a/lang/values.md
+++ b/lang/values.md
@@ -201,7 +201,7 @@ impl Type {
     }
     fn encode(Tuple { fields: [field1, field2], size }: Self, val: Value) -> List<AbstractByte> {
         let Value::Tuple([val1, val2]) = val else { panic!() };
-        let mut bytes = [AbstractByte::Uninit; size];
+        let mut bytes = list![AbstractByte::Uninit; size];
         let (offset1, type1) = field1;
         bytes[offset1..][..type1.size()] = type1.encode(val1);
         let (offset2, type2) = field2;

--- a/lang/values.md
+++ b/lang/values.md
@@ -63,7 +63,7 @@ impl Type {
     /// Note that it is a spec bug if `v` is not valid according to `ty`!
     ///
     /// See below for the general properties relation `encode` and `decode`.
-    fn encode(self, v: Value) -> List<AbstractByte>;
+    fn encode(self, val: Value) -> List<AbstractByte>;
 }
 ```
 
@@ -234,7 +234,7 @@ impl Type {
         }
         Value::Union(chunk_data)
     }
-    fn encode(Type::Union { size, chunks, .. }: Self, value: Value) -> List<AbstractByte> {
+    fn encode(Type::Union { size, chunks, .. }: Self, val: Value) -> List<AbstractByte> {
         let Value::Union(chunk_data) = val else { panic!() };
         assert_eq!(chunk_data.len(), chunks.len());
         let mut bytes = list![AbstractByte::Uninit; size];
@@ -390,7 +390,7 @@ trait TypedMemory: MemoryInterface {
         let bytes = self.load(ptr, pty.type.size(), pty.align)?;
         match pty.type.decode(bytes) {
             Some(val) => val,
-            None => throw_ub!("load at type {ty} but the data in memory violates the validity invariant"),
+            None => throw_ub!("load at type {pty} but the data in memory violates the validity invariant"),
         }
     }
 

--- a/lang/values.md
+++ b/lang/values.md
@@ -237,7 +237,7 @@ impl Type {
     fn encode(Union { size, chunks, .. }: Self, value: Value) -> List<AbstractByte> {
         let Value::Union(chunk_data) = val else { panic!() };
         assert_eq!(chunk_data.len(), chunks.len());
-        let mut bytes = [AbstractByte::Uninit; size];
+        let mut bytes = list![AbstractByte::Uninit; size];
         // Restore the data from each chunk.
         for ((offset, size), data) in chunks.iter().zip(chunk_data.iter()) {
             assert_eq!(data.len(), size);

--- a/lang/values.md
+++ b/lang/values.md
@@ -414,7 +414,7 @@ We could decide that this is an "if and only if", i.e., that the validity invari
 ```rust
 fn bytes_valid_for_type(ty: Type, bytes: List<AbstractByte>) -> Result {
     if ty.decode(bytes).is_none() {
-        throw_ub!("data violates validity invariant of type {ty}"),
+        throw_ub!("data violates validity invariant of type {ty}");
     }
 }
 ```

--- a/lang/well-formed.md
+++ b/lang/well-formed.md
@@ -247,25 +247,25 @@ impl Statement {
                 let left = destination.check(live_locals)?;
                 let right = source.check(live_locals)?;
                 ensure(left.type == right)?;
-                locals
+                live_locals
             }
             Statement::Finalize { place } => {
                 place.check(live_locals)?;
-                locals
+                live_locals
             }
             Statement::StorageLive(local) => {
                 // Look up the type in the function, and add it to the live locals.
                 // Fail if it already is live.
-                locals.try_insert(local, func.locals.get(local)?)?;
-                locals
+                live_locals.try_insert(local, func.locals.get(local)?)?;
+                live_locals
             }
             Statement::StorageDead(local) => {
                 if func.ret.0 == local || func.args.iter().any(|(arg_name, _abi)| arg_name == local) {
                     // Trying to mark an argument or the return local as dead.
                     throw!();
                 }
-                locals.remove(local)?;
-                locals
+                live_locals.remove(local)?;
+                live_locals
             }
         }
     }

--- a/lang/well-formed.md
+++ b/lang/well-formed.md
@@ -127,15 +127,15 @@ impl Value {
 impl ValueExpr {
     fn check(self, locals: Map<Local, PlaceType>) -> Option<Type> {
         match self {
-            Constant(value, type) => {
+            ValueExpr::Constant(value, type) => {
                 value.check(type)?;
                 type
             }
-            Load { source, destructive: _ } => {
+            ValueExpr::Load { source, destructive: _ } => {
                 let ptype = source.check(locals)?;
                 ptype.type
             }
-            Ref { target, align, mutbl } => {
+            ValueExpr::Ref { target, align, mutbl } => {
                 let ptype = target.check(locals)?;
                 // If `align > ptype.align`, then this operation would be "unsafe"
                 // since the reference promises more alignment than what the place
@@ -143,41 +143,41 @@ impl ValueExpr {
                 // to packed fields.
                 ensure(align <= ptype.align)?;
                 let pointee = Layout { align, ..ptype.layout() };
-                Ref { mutbl, pointee }
+                Type::Ref { mutbl, pointee }
             }
-            AddrOf { target } => {
+            ValueExpr::AddrOf { target } => {
                 target.check(locals)?;
-                RawPtr
+                Type::RawPtr
             }
-            UnOp { operator, operand } => {
+            ValueExpr::UnOp { operator, operand } => {
                 let operand = operand.check(locals)?;
                 match operator {
-                    Int(_int_op, int_ty) => {
-                        ensure(matches!(operand, Int(_)))?;
-                        Int(int_ty)
+                    UnOp::Int(_int_op, int_ty) => {
+                        ensure(matches!(operand, Type::Int(_)))?;
+                        Type::Int(int_ty)
                     }
-                    Ptr2Int => {
-                        ensure(matches!(operand, RawPtr))?;
-                        Int(IntType { signed: Unsigned, size: PTR_SIZE })
+                    UnOp::Ptr2Int => {
+                        ensure(matches!(operand, Type::RawPtr))?;
+                        Type::Int(IntType { signed: Unsigned, size: PTR_SIZE })
                     }
-                    Int2Ptr => {
-                        ensure(matches!(operand, Int(IntType { signed: Unsigned, size: PTR_SIZE })))?;
-                        RawPtr
+                    UnOp::Int2Ptr => {
+                        ensure(matches!(operand, Type::Int(IntType { signed: Unsigned, size: PTR_SIZE })))?;
+                        Type::RawPtr
                     }
                 }
             }
-            BinOp { operator, left, right } => {
+            ValueExpr::BinOp { operator, left, right } => {
                 let left = left.check(locals)?;
                 let right = right.check(locals)?;
                 match operator {
-                    Int(_int_op, int_ty) => {
-                        ensure(matches!(left, Int(_)))?;
-                        ensure(matches!(right, Int(_)))?;
-                        Int(int_ty)
+                    BinOp::Int(_int_op, int_ty) => {
+                        ensure(matches!(left, Type::Int(_)))?;
+                        ensure(matches!(right, Type::Int(_)))?;
+                        Type::Int(int_ty)
                     }
-                    PtrOffset { inbounds: _ } => {
-                        ensure(matches!(left, Ref { .. } | RawPtr))?;
-                        ensure(matches!(right, Int(_)))?;
+                    BinOp::PtrOffset { inbounds: _ } => {
+                        ensure(matches!(left, Type::Ref { .. } | Type::RawPtr))?;
+                        ensure(matches!(right, Type::Int(_)))?;
                         left
                     }
                 }
@@ -189,17 +189,17 @@ impl ValueExpr {
 impl PlaceExpr {
     fn check(self, locals: Map<Local, PlaceType>) -> Option<PlaceType> {
         match self {
-            Local(name) => locals.get(name),
-            Deref { operand, ptype } => {
+            PlaceExpr::Local(name) => locals.get(name),
+            PlaceExpr::Deref { operand, ptype } => {
                 let type = operand.check(locals)?;
-                ensure(matches!(type, Ref { .. } | RawPtr))?;
+                ensure(matches!(type, Type::Ref { .. } | Type::RawPtr))?;
                 ptype
             }
-            Field { root, field } => {
+            PlaceExpr::Field { root, field } => {
                 let root = root.check(locals)?;
                 let (offset, field_ty) = match root.type {
-                    Tuple { fields, .. } => fields.get(field)?,
-                    Union { fields, .. } => fields.get(field)?,
+                    Type::Tuple { fields, .. } => fields.get(field)?,
+                    Type::Union { fields, .. } => fields.get(field)?,
                     _ => throw!(),
                 };
                 PlaceType {
@@ -207,12 +207,12 @@ impl PlaceExpr {
                     type: field_ty,
                 }
             }
-            Index { root, index } => {
+            PlaceExpr::Index { root, index } => {
                 let root = root.check(locals)?;
                 let index = index.check(locals)?;
-                ensure(matches!(index, Int(_)))?;
+                ensure(matches!(index, Type::Int(_)))?;
                 let field_ty = match root.type {
-                    Array { elem, .. } => elem,
+                    Type::Array { elem, .. } => elem,
                     _ => throw!(),
                 };
                 // We might be adding a multiple of `field_ty.size`, so we have to
@@ -243,23 +243,23 @@ impl Statement {
         func: Function
     ) -> Option<Map<Local, PlaceType>> {
         match self {
-            Assign { destination, source } => {
+            Statement::Assign { destination, source } => {
                 let left = destination.check(live_locals)?;
                 let right = source.check(live_locals)?;
                 ensure(left.type == right)?;
                 locals
             }
-            Finalize { place } => {
+            Statement::Finalize { place } => {
                 place.check(live_locals)?;
                 locals
             }
-            StorageLive(local) => {
+            Statement::StorageLive(local) => {
                 // Look up the type in the function, and add it to the live locals.
                 // Fail if it already is live.
                 locals.try_insert(local, func.locals.get(local)?)?;
                 locals
             }
-            StorageDead(local) => {
+            Statement::StorageDead(local) => {
                 if func.ret.0 == local || func.args.iter().any(|(arg_name, _abi)| arg_name == local) {
                     // Trying to mark an argument or the return local as dead.
                     throw!();
@@ -278,18 +278,18 @@ impl Terminator {
         live_locals: Map<Local, PlaceType>,
     ) -> Option<List<BbName>> {
         match self {
-            Goto(block_name) => {
+            Terminator::Goto(block_name) => {
                 list![block_name]
             }
-            If { condition, then_block, else_block } => {
+            Terminator::If { condition, then_block, else_block } => {
                 let type = condition.check(live_locals)?;
                 ensure(matches!(type, Type::Bool))?;
                 list![then_block, else_block]
             }
-            Unreachable => {
+            Terminator::Unreachable => {
                 list![]
             }
-            Call { callee: _, arguments, ret, next_block } => {
+            Terminator::Call { callee: _, arguments, ret, next_block } => {
                 // Argument and return expressions must all typecheck with some type.
                 for (arg, _abi) in arguments {
                     arg.check(live_locals)?;
@@ -298,7 +298,7 @@ impl Terminator {
                 ret_place.check(live_locals)?;
                 list![next_block]
             }
-            Return => {
+            Terminator::Return => {
                 list![]
             }
         }

--- a/mem/basic.md
+++ b/mem/basic.md
@@ -99,7 +99,7 @@ impl MemoryInterface for BasicMemory {
             align,
             live: true,
             contents: list![AbstractByte::Uninit; size],
-        }
+        };
 
         // Insert it into list, and remember where.
         let id = AllocId(self.allocations.len());
@@ -130,7 +130,7 @@ impl MemoryInterface for BasicMemory {
         }
 
         // Mark it as dead. That's it.
-        allocation.live = false.
+        allocation.live = false;
     }
 }
 ```
@@ -159,7 +159,7 @@ impl BasicMemory {
             }
             // Zero-sized accesses are fine.
             return None;
-        }
+        };
         let allocation = &self.allocations[id.0];
         // Compute relative offset, and ensure we are in-bounds.
         let offset_in_alloc = ptr.addr - allocation.addr;
@@ -175,7 +175,7 @@ impl MemoryInterface for BasicMemory {
     fn load(&mut self, ptr: Pointer<AllocId>, len: Size, align: Align) -> Result<List<AbstractByte<AllocId>>> {
         let Some((id, offset)) = self.check_ptr(ptr, len, align)? else {
             return list![];
-        }
+        };
         let allocation = &self.allocations[id.0];
 
         // Slice into the contents, and copy them to a new list.
@@ -185,7 +185,7 @@ impl MemoryInterface for BasicMemory {
     fn store(&mut self, ptr: Self::Pointer, bytes: List<Self::AbstractByte>, align: Align) -> Result {
         let Some((id, offset)) = self.check_ptr(ptr, bytes.len(), align)? else {
             return;
-        }
+        };
         let allocation = &mut self.allocations[id.0];
 
         // Slice into the contents, and put the new bytes there.

--- a/mem/basic.md
+++ b/mem/basic.md
@@ -154,7 +154,7 @@ impl BasicMemory {
         // Now try to access the allocation information.
         let Some(id) = ptr.provenance else {
             // An invalid pointer.
-            if size != 0 {
+            if len != 0 {
                 throw_ub!("non-zero-sized access with invalid pointer");
             }
             // Zero-sized accesses are fine.
@@ -189,7 +189,7 @@ impl MemoryInterface for BasicMemory {
         let allocation = &mut self.allocations[id.0];
 
         // Slice into the contents, and put the new bytes there.
-        allocation.contents[offset..][..len].copy_from_slice(bytes);
+        allocation.contents[offset..][..bytes.len()].copy_from_slice(bytes);
     }
 
     fn dereferenceable(&self, ptr: Self::Pointer, size: Size, align: Align) -> Result {

--- a/mem/interface.md
+++ b/mem/interface.md
@@ -44,15 +44,15 @@ enum AbstractByte<Provenance> {
 impl AbstractByte<Provenance> {
     fn data(self) -> Option<u8> {
         match self {
-            Uninit => None,
-            Init(data, _) => Some(data),
+            AbstractByte::Uninit => None,
+            AbstractByte::Init(data, _) => Some(data),
         }
     }
 
     fn provenance(self) -> Option<Provenance> {
         match self {
-            Uninit => None,
-            Init(_, provenance) => provenance,
+            AbstractByte::Uninit => None,
+            AbstractByte::Init(_, provenance) => provenance,
         }
     }
 }

--- a/mem/interface.md
+++ b/mem/interface.md
@@ -41,7 +41,7 @@ enum AbstractByte<Provenance> {
     Init(u8, Option<Provenance>),
 }
 
-impl AbstractByte<Provenance> {
+impl<Provenance> AbstractByte<Provenance> {
     fn data(self) -> Option<u8> {
         match self {
             AbstractByte::Uninit => None,

--- a/mem/intptrcast.md
+++ b/mem/intptrcast.md
@@ -15,7 +15,7 @@ struct IntPtrCast<Provenance: Eq> {
     exposed: Set<Provenance>,
 }
 
-impl IntPtrCast<Provenance> {
+impl<Provenance: Eq> IntPtrCast<Provenance> {
     fn ptr2int(&mut self, ptr: Pointer<Provenance>) -> Result<BigInt> {
         if let Some(provenance) = ptr.provenance {
             // Remember this provenance as having been exposed.


### PR DESCRIPTION
Most commits are typo fixes, but a few are non-trivial changes:

- Changed `Terminator::Goto(BasicBlock)` to `Terminator::Goto(BbName)`, because the rest of the code used it as BbName.
- Changed `use Memory::{Provenance, Pointer, AbstractByte};` to `type Provenance = Memory::Provenance; ...` because it is valid Rust (or should this be valid PseudoRust?)
- Changed `EnumVariant` to `Enum::EnumVariant`, where it was missing (or should this be valid PseudoRust?)
- Changed `Local` to `LocalName` in well-formed (Local is not defined, I presume it was intended to mean LocalName)