### PR TITLE
Support slice type and pointer-unsize cast

### DIFF
--- a/lang/operator.md
+++ b/lang/operator.md
@@ -50,6 +50,20 @@ impl Machine {
 }
 ```
 
+### Pointer unsize cast
+
+```rust
+impl Machine {
+    fn eval_un_op(&mut self, PtrUnsize(pointee): UnOp, operand: Value) -> NdResult<Value> {
+        let Value::Ptr(ptr) = operand else { panic!("non-pointer input to ptr-unsize cast") };
+        assert!(ptr.meta.is_none(), "fat-pointer input to ptr-unsize cast") };
+        let Type::Array { elem, count } = pointee else { panic!("non-array pointee type to ptr-unsize cast") };
+
+        Value::Ptr(PointerRepr { meta: Some(count), ..ptr })
+    }
+}
+```
+
 ## Binary operators
 
 ```rust

--- a/lang/syntax.md
+++ b/lang/syntax.md
@@ -132,6 +132,8 @@ enum ValueExpr {
         left: ValueExpr,
         right: ValueExpr,
     },
+    /// Get the length of the place
+    Len(PlaceExpr),
 }
 
 enum UnOpInt {
@@ -147,6 +149,8 @@ enum UnOp {
     Ptr2Int,
     /// Integer-to-pointer cast
     Int2Ptr,
+    /// Cast a thin pointer to a fat pointer.
+    PtrUnsize(Type),
 }
 
 enum BinOpInt {

--- a/lang/values.md
+++ b/lang/values.md
@@ -185,27 +185,24 @@ Note that types like `&!` have no valid value: when the pointee type is uninhabi
   (The latter would not even be possible with the current structure of MiniRust.)
   Also see [this discussion](https://github.com/rust-lang/unsafe-code-guidelines/issues/77).
 
-### Tuples (and arrays, structs, ...)
-
-For simplicity, we only define pairs for now.
+### Tuples (and structs, ...)
 
 ```rust
 impl Type {
-    fn decode(Tuple { fields: [field1, field2], size }: Self, bytes: List<AbstractByte>) -> Option<Value> {
+    fn decode(Tuple { fields, size }: Self, bytes: List<AbstractByte>) -> Option<Value> {
         if bytes.len() != size { throw!(); }
-        let (offset1, type1) = field1;
-        let val1 = type1.decode(bytes[offset1..][..type1.size()]);
-        let (offset2, type2) = field2;
-        let val2 = type2.decode(bytes[offset2..][..type2.size()]);
-        Value::Tuple([val1, val2])
+        Value::Tuple(
+            fields.into_iter().map(|(offset, ty)| {
+                ty.decode(bytes[offset..][..ty.size()])
+            }).try_collect()?,
+        )
     }
-    fn encode(Tuple { fields: [field1, field2], size }: Self, val: Value) -> List<AbstractByte> {
-        let Value::Tuple([val1, val2]) = val else { panic!() };
-        let mut bytes = [AbstractByte::Uninit; size];
-        let (offset1, type1) = field1;
-        bytes[offset1..][..type1.size()] = type1.encode(val1);
-        let (offset2, type2) = field2;
-        bytes[offset2..][..type2.size()] = type2.encode(val2);
+    fn encode(Tuple { fields, size }: Self, val: Value) -> List<AbstractByte> {
+        let Value::Tuple(values) = val else { panic!() };
+        let mut bytes = list![AbstractByte::Uninit; size];
+        for ((offset, ty), value) in fields.into_iter().zip(values) {
+            bytes[offset..][..ty.size()].copy_from_slice(ty.encode(value));
+        }
         bytes
     }
 }
@@ -214,6 +211,32 @@ impl Type {
 Note in particular that `decode` ignores the bytes which are before, between, or after the fields (usually called "padding").
 `encode` in turn always and deterministically makes those bytes `Uninit`.
 (The [generic properties](#generic-properties) defined below make this the only possible choice for `encode`.)
+
+### Arrays
+
+```rust
+impl Type {
+    fn decode(Array { elem, count }: Self, bytes: List<AbstractByte>) -> Option<Value> {
+        if bytes.len() != elem.size() * count { throw!(); }
+        Value::Tuple(
+            bytes.chunks(elem.size())
+                .map(|elem_bytes| elem.decode(elem_bytes))
+                .try_collect()?,
+        )
+    }
+    fn encode(Array { elem, count }: Self, val: Value) -> List<AbstractByte> {
+        let Value::Tuple(values) = val else { panic!() };
+        assert_eq!(values.len(), count);
+        values.into_iter().flat_map(|value| {
+            let bytes = elem.encode(value);
+            assert_eq!(bytes.len(), elem.size());
+            bytes
+        }).collect()
+    }
+}
+```
+
+- TODO: Should we consider paddings between two adjacent elements in arrays?
 
 ### Unions
 


### PR DESCRIPTION
This PR implements part of #1.

It adds optional metadata in the pointer value and the place representation.

Slices' subslice is not supported yet. In MIRI, it seems to be a function call of `Index::<impl RangeBounds<usize>>::index`. I'm not sure how should mini-rust deal with it.

TODO: need to check the files manually one by one.
- [ ] `prelude.md`
- [ ] `types.md`
- [ ] `values.md`
- [ ] `well-formed.md`
- [ ] `syntax.md`
- [ ] `machine.md`
- [ ] `step.md`
- [ ] `operator.md`