### PR TITLE
renamed identifiers `type` to `ty`

### DIFF
--- a/lang/step.md
+++ b/lang/step.md
@@ -50,7 +50,7 @@ Constants are trivial, as one would hope.
 
 ```rust
 impl Machine {
-    fn eval_value(&mut self, ValueExpr::Constant(value, _type): ValueExpr) -> NdResult<Value> {
+    fn eval_value(&mut self, ValueExpr::Constant(value, _ty): ValueExpr) -> NdResult<Value> {
         value
     }
 }
@@ -170,24 +170,24 @@ impl Machine {
 ```rust
 impl Machine {
     fn eval_place(&mut self, PlaceExpr::Field { root, field }: PlaceExpr) -> NdResult<Place> {
-        let type = root.check(self.cur_frame().func.locals).unwrap().type;
+        let ty = root.check(self.cur_frame().func.locals).unwrap().ty;
         let root = self.eval_place(root)?;
-        let offset = match type {
+        let offset = match ty {
             Type::Tuple { fields, .. } => fields[field].0,
             Type::Union { fields, .. } => fields[field].0,
             _ => panic!("field projection on non-projectable type"),
         };
-        assert!(offset < type.size());
+        assert!(offset < ty.size());
         self.ptr_offset_inbounds(root, offset.bytes())?
     }
 
     fn eval_place(&mut self, PlaceExpr::Index { root, index }: PlaceExpr) -> NdResult<Place> {
-        let type = root.check(self.cur_frame().func.locals).unwrap().type;
+        let ty = root.check(self.cur_frame().func.locals).unwrap().ty;
         let root = self.eval_place(root)?;
         let Value::Int(index) = self.eval_value(index)? else {
             panic!("non-integer operand for array index")
         };
-        let offset = match type {
+        let offset = match ty {
             Type::Array { elem, count } => {
                 if index < count {
                     index * elem.size()
@@ -197,7 +197,7 @@ impl Machine {
             }
             _ => panic!("index projection on non-indexable type"),
         };
-        assert!(offset < type.size());
+        assert!(offset < ty.size());
         self.ptr_offset_inbounds(root, offset.bytes())?
     }
 }

--- a/lang/types.md
+++ b/lang/types.md
@@ -96,7 +96,7 @@ enum TagEncoding { /* ... */ }
 
 /// "Place" types are laid out in memory and thus also have an alignment requirement.
 struct PlaceType {
-    type: Type,
+    ty: Type,
     align: Align,
 }
 ```
@@ -126,24 +126,24 @@ impl Type {
         match self {
             Int(..) | Bool | RawPtr { .. } => true,
             Ref { pointee, .. } | Box { pointee } => pointee.inhabited,
-            Tuple { fields, .. } => fields.iter().all(|type| type.inhabited()),
+            Tuple { fields, .. } => fields.iter().all(|ty| ty.inhabited()),
             Array { elem, count } => count == 0 || elem.inhabited(),
             Union { .. } => true,
-            Enum { variants, .. } => variants.iter().any(|type| type.inhabited()),
+            Enum { variants, .. } => variants.iter().any(|ty| ty.inhabited()),
         }
     }
 }
 
 impl PlaceType {
-    fn new(type: Type, align: Align) -> Self {
-        PlaceType { type, align }
+    fn new(ty: Type, align: Align) -> Self {
+        PlaceType { ty, align }
     }
 
     fn layout(self) -> Layout {
         Layout {
-            size: self.type.size(),
+            size: self.ty.size(),
             align: self.align,
-            inhabited: self.type.inhabited(),
+            inhabited: self.ty.inhabited(),
         }
     }
 }

--- a/lang/values.md
+++ b/lang/values.md
@@ -53,7 +53,7 @@ impl Type {
     /// Decode a list of bytes into a value. This can fail, which typically means Undefined Behavior.
     /// `decode` must satisfy the following property:
     /// ```
-    /// type.decode(bytes) = Some(_) -> bytes.len() == type.size() && type.inhabited()`
+    /// ty.decode(bytes) = Some(_) -> bytes.len() == ty.size() && ty.inhabited()`
     /// ```
     /// In other words, all valid low-level representations must have the length given by the size of the type,
     /// and the existence of a valid low-level representation implies that the type is inhabited.
@@ -410,14 +410,14 @@ trait TypedMemory: MemoryInterface {
     /// Write a value of the given type to memory.
     /// Note that it is a spec bug if `val` cannot be encoded at `ty`!
     fn typed_store(&mut self, ptr: Self::Pointer, val: Value, pty: PlaceType) -> Result {
-        let bytes = pty.type.encode(val);
+        let bytes = pty.ty.encode(val);
         self.store(ptr, bytes, pty.align)?;
     }
 
     /// Read a value of the given type.
     fn typed_load(&mut self, ptr: Self::Pointer, pty: PlaceType) -> Result<Value> {
-        let bytes = self.load(ptr, pty.type.size(), pty.align)?;
-        match pty.type.decode(bytes) {
+        let bytes = self.load(ptr, pty.ty.size(), pty.align)?;
+        match pty.ty.decode(bytes) {
             Some(val) => val,
             None => throw_ub!("load at type {pty} but the data in memory violates the validity invariant"),
         }


### PR DESCRIPTION
`type` was renamed to `ty`, as `type` is a Rust keyword.