### PR TITLE
some fixes

### DIFF
--- a/lang/operator.md
+++ b/lang/operator.md
@@ -26,7 +26,7 @@ impl<M: Memory> Machine<M> {
         let Value::Int(operand) = operand else { panic!("non-integer input to integer operation") };
 
         // Perform the operation.
-        let result = self.eval_un_op_int(op, operand);
+        let result = self.eval_un_op_int(op, operand)?;
         // Put the result into the right range (in case of overflow).
         let result = result.modulo(int_type.signed, int_type.size);
         Value::Int(result)
@@ -83,7 +83,7 @@ impl<M: Memory> Machine<M> {
         let Value::Int(right) = right else { panic!("non-integer input to integer operation") };
 
         // Perform the operation.
-        let result = self.eval_bin_op_int(op, left, right);
+        let result = self.eval_bin_op_int(op, left, right)?;
         // Put the result into the right range (in case of overflow).
         let result = result.modulo(int_type.signed, int_type.size);
         Value::Int(result)

--- a/lang/step.md
+++ b/lang/step.md
@@ -56,13 +56,13 @@ impl<M: Memory> Machine<M> {
             Constant::Int(i) => Value::Int(i),
             Constant::Bool(b) => Value::Bool(b),
             Constant::Tuple(args) => {
-                let args = args.into_iter()
-                    .map(|arg| self.eval_constant(arg))
-                    .collect();
-                Value::Tuple(args)
+                let vals = args.into_iter()
+                    .map(|c| self.eval_constant(c))
+                    .try_collect()?;
+                Value::Tuple(vals)
             },
             Constant::Variant { idx, data } => {
-                let data = self.eval_constant(data);
+                let data = self.eval_constant(data)?;
                 Value::Variant { idx, data }
             },
         }
@@ -220,7 +220,7 @@ Here we define how statements are evaluated.
 ```rust
 impl<M: Memory> Machine<M> {
     #[specr::argmatch(statement)]
-    fn eval_statement(&mut self, statement: Statement);
+    fn eval_statement(&mut self, statement: Statement) -> NdResult;
 }
 ```
 
@@ -292,7 +292,7 @@ impl<M: Memory> Machine<M> {
 ```rust
 impl<M: Memory> Machine<M> {
     #[specr::argmatch(terminator)]
-    fn eval_terminator(&mut self, terminator: Terminator);
+    fn eval_terminator(&mut self, terminator: Terminator) -> NdResult;
 }
 ```
 

--- a/lang/well-formed.md
+++ b/lang/well-formed.md
@@ -53,7 +53,7 @@ impl Type {
             Pointer(ptr_type) => {
                 ptr_type.check_wf()?;
             }
-            Tuple { fields, size, align } => {
+            Tuple { fields, size } => {
                 // The fields must not overlap.
                 // We check fields in the order of their (absolute) offsets.
                 fields.sort_by_key(|(offset, _ty)| offset);

--- a/mem/interface.md
+++ b/mem/interface.md
@@ -82,7 +82,7 @@ pub struct Pointer<Provenance> {
 /// executing the same operation on the same memory can have different results.
 /// We also let read operations potentially mutate memory (they actually can
 /// change the current state in concurrent memory models and in Stacked Borrows).
-pub trait Memory {
+pub trait Memory: Sized {
     /// The type of pointer provenance.
     type Provenance: Eq;
 

--- a/mem/intptrcast.md
+++ b/mem/intptrcast.md
@@ -16,7 +16,7 @@ pub struct IntPtrCast<Provenance: Eq> {
 }
 
 impl<Provenance: Eq> IntPtrCast<Provenance> {
-    fn ptr2int(&mut self, ptr: Pointer<Provenance>) -> Result<BigInt> {
+    pub fn ptr2int(&mut self, ptr: Pointer<Provenance>) -> Result<BigInt> {
         if let Some(provenance) = ptr.provenance {
             // Remember this provenance as having been exposed.
             self.exposed.insert(provenance);
@@ -24,7 +24,7 @@ impl<Provenance: Eq> IntPtrCast<Provenance> {
         ptr.addr
     }
 
-    fn int2ptr(&mut self, addr: BigInt) -> NdResult<Pointer<Provenance>> {
+    pub fn int2ptr(&mut self, addr: BigInt) -> NdResult<Pointer<Provenance>> {
         // Predict a suitable provenance. It must be either `None` or already exposed.
         let provenance = predict(|prov: Option<Provenance>| {
             prov.map_or(


### PR DESCRIPTION
Remark:
`Memory: Sized` is apparently necessary due to the `Value<Self>` argument in `fn typed_store`