### PR TITLE
crate specr

### DIFF
--- a/lang/operator.md
+++ b/lang/operator.md
@@ -28,7 +28,7 @@ impl<M: Memory> Machine<M> {
         // Perform the operation.
         let result = self.eval_un_op_int(op, operand)?;
         // Put the result into the right range (in case of overflow).
-        let result = result.modulo(int_type.signed, int_type.size);
+        let result = modulo(result, int_type.signed, int_type.size);
         Value::Int(result)
     }
 }
@@ -85,7 +85,7 @@ impl<M: Memory> Machine<M> {
         // Perform the operation.
         let result = self.eval_bin_op_int(op, left, right)?;
         // Put the result into the right range (in case of overflow).
-        let result = result.modulo(int_type.signed, int_type.size);
+        let result = modulo(result, int_type.signed, int_type.size);
         Value::Int(result)
     }
 }
@@ -97,20 +97,20 @@ impl<M: Memory> Machine<M> {
 impl<M: Memory> Machine<M> {
     /// Perform a wrapping offset on the given pointer. (Can never fail.)
     fn ptr_offset_wrapping(&self, ptr: Pointer<M::Provenance>, offset: BigInt) -> Pointer<M::Provenance> {
-        let offset = offset.modulo(Signed, M::PTR_SIZE);
+        let offset = modulo(offset, Signed, M::PTR_SIZE);
         let addr = ptr.addr + offset;
-        let addr = addr.modulo(Unsigned, M::PTR_SIZE);
+        let addr = modulo(addr, Unsigned, M::PTR_SIZE);
         Pointer { addr, ..ptr }
     }
 
     /// Perform in-bounds arithmetic on the given pointer. This must not wrap,
     /// and the offset must stay in bounds of a single allocation.
     fn ptr_offset_inbounds(&self, ptr: Pointer<M::Provenance>, offset: BigInt) -> NdResult<Pointer<M::Provenance>> {
-        if !offset.in_bounds(Signed, M::PTR_SIZE) {
+        if !in_bounds(offset, Signed, M::PTR_SIZE) {
             throw_ub!("inbounds offset does not fit into `isize`");
         }
         let addr = ptr.addr + offset;
-        if !addr.in_bounds(Unsigned, M::PTR_SIZE) {
+        if !in_bounds(addr, Unsigned, M::PTR_SIZE) {
             throw_ub!("overflowing inbounds pointer arithmetic");
         }
         let new_ptr = Pointer { addr, ..ptr };

--- a/lang/well-formed.md
+++ b/lang/well-formed.md
@@ -127,7 +127,7 @@ impl Constant {
         // TODO: add more.
         match (self, ty) {
             (Constant::Int(i), Type::Int(int_type)) => {
-                ensure(i.in_bounds(int_type.signed, int_type.size))?;
+                ensure(in_bounds(i, int_type.signed, int_type.size))?;
             }
             (Constant::Bool(_), Type::Bool) => (),
             (Constant::Tuple(constants), Type::Tuple { fields }) => {

--- a/mem/basic.md
+++ b/mem/basic.md
@@ -95,7 +95,7 @@ impl Memory for BasicMemory {
             // ... that is suitably aligned...
             if addr % align != 0 { return false; }
             // ... such that addr+size is in-bounds of a `usize`...
-            if !(addr+size.bytes()).in_bounds(Unsigned, Self::PTR_SIZE) { return false; }
+            if !in_bounds(addr+size.bytes(), Unsigned, Self::PTR_SIZE) { return false; }
             // ... and it does not overlap with any existing live allocation.
             if self.allocations.values().any(|a| a.live && a.overlaps(addr, size)) { return false; }
             // If all tests pass, we are good!
@@ -233,7 +233,7 @@ A size is valid, whenever it is non-negative and in-bounds for signed `PTR_SIZE`
 ```rust
 impl Memory for BasicMemory {
     fn valid_size(size: Size) -> bool {
-        size.in_bounds(Signed, Self::PTR_SIZE) && size >= 0
+        in_bounds(size, Signed, Self::PTR_SIZE) && size >= 0
     }
 }
 ```

--- a/prelude/bigint.md
+++ b/prelude/bigint.md
@@ -18,36 +18,36 @@ impl BigInt {
 
     /// Computes `self / other`, returns None if `other` is zero.
     pub fn checked_div(other: impl Into<BigInt>) -> Option<BigInt>;
+}
 
-    /// Returns the unique value that is equal to `self` modulo `2^size.bits()`.
-    /// If `signed == Unsigned`, the result is in the interval `0..2^size.bits()`,
-    /// else it is in the interval `-2^(size.bits()-1) .. 2^(size.bits()-1)`.
-    ///
-    /// `size` must not be zero.
-    pub fn modulo(self, signed: Signedness, size: Size) -> BigInt {
-        if size == 0 {
-            panic!("BigInt::modulo received invalid size zero!");
-        }
-
-        // the modulus.
-        let m = BigInt::from(2).pow(size.bits());
-
-        // n is in range `-(m-1)..m`.
-        let n = self % m;
-
-        match signed {
-            // if `Unsigned`, output needs to be in range `0..m`:
-            Unsigned if n < 0 => n + m,
-            // if `Signed`, output needs to be in range `-m/2 .. m/2`:
-            Signed if n >= m/2 => n - m,
-            Signed if n < -m/2 => n + m,
-            _ => n,
-        }
+/// Returns the unique value that is equal to `i` modulo `2^size.bits()`.
+/// If `signed == Unsigned`, the result is in the interval `0..2^size.bits()`,
+/// else it is in the interval `-2^(size.bits()-1) .. 2^(size.bits()-1)`.
+///
+/// `size` must not be zero.
+pub fn modulo(i: BigInt, signed: Signedness, size: Size) -> BigInt {
+    if size == 0 {
+        panic!("BigInt::modulo received invalid size zero!");
     }
 
-    /// Tests whether an integer is in-bounds of a finite integer type.
-    pub fn in_bounds(self, signed: Signedness, size: Size) -> bool {
-        self == self.modulo(signed, size)
+    // the modulus.
+    let m = BigInt::from(2).pow(size.bits());
+
+    // n is in range `-(m-1)..m`.
+    let n = i % m;
+
+    match signed {
+        // if `Unsigned`, output needs to be in range `0..m`:
+        Unsigned if n < 0 => n + m,
+        // if `Signed`, output needs to be in range `-m/2 .. m/2`:
+        Signed if n >= m/2 => n - m,
+        Signed if n < -m/2 => n + m,
+        _ => n,
     }
+}
+
+/// Tests whether an integer `i` is in-bounds of a finite integer type.
+pub fn in_bounds(i: BigInt, signed: Signedness, size: Size) -> bool {
+    i == modulo(i, signed, size)
 }
 ```


### PR DESCRIPTION
The commit makes `BigInt::{modulo, in_bounds}` a free function instead of a method.
So that `specr` can become a crate instead of a module.

Btw, we have two crates now called `specr` (ugh!)
I think we should rename specr (the transpiler) to `specr-transpile` or something.