### PR TITLE
add Size::ZERO, Align::ONE constants

### DIFF
--- a/lang/machine.md
+++ b/lang/machine.md
@@ -39,7 +39,7 @@ struct StackFrame<M: Memory> {
 
     /// If `next_stmt` is equal to the number of statements in this block (an
     /// out-of-bounds index in the statement list), it refers to the terminator.
-    next_stmt: BigInt,
+    next_stmt: Int,
 }
 ```
 
@@ -65,7 +65,7 @@ impl<M: Memory> StackFrame<M> {
     /// jump to the beginning of the given block.
     fn jump_to_block(&mut self, b: BbName) -> NdResult {
         self.next_block = b;
-        self.next_stmt = BigInt::ZERO;
+        self.next_stmt = Int::ZERO;
     }
 }
 ```

--- a/lang/machine.md
+++ b/lang/machine.md
@@ -65,7 +65,7 @@ impl<M: Memory> StackFrame<M> {
     /// jump to the beginning of the given block.
     fn jump_to_block(&mut self, b: BbName) -> NdResult {
         self.next_block = b;
-        self.next_stmt = BigInt::zero();
+        self.next_stmt = BigInt::ZERO;
     }
 }
 ```

--- a/lang/operator.md
+++ b/lang/operator.md
@@ -126,7 +126,7 @@ impl<M: Memory> Machine<M> {
         // `offset.abs()` will fit into a `Size` since we did the overflow check above.
         // FIXME: actually, it could be isize::MIN and then everything breaks? Is that
         // a valid offset?
-        self.mem.dereferenceable(min_ptr, Size::from_bytes(offset.abs()), Align::one())?;
+        self.mem.dereferenceable(min_ptr, Size::from_bytes(offset.abs()), Align::ONE)?;
         // If this check passed, we are good.
         new_ptr
     }

--- a/lang/operator.md
+++ b/lang/operator.md
@@ -15,7 +15,7 @@ impl<M: Memory> Machine<M> {
 
 ```rust
 impl<M: Memory> Machine<M> {
-    fn eval_un_op_int(&mut self, op: UnOpInt, operand: BigInt) -> NdResult<BigInt> {
+    fn eval_un_op_int(&mut self, op: UnOpInt, operand: Int) -> NdResult<Int> {
         use UnOpInt::*;
         match op {
             Neg => -operand,
@@ -64,7 +64,7 @@ impl<M: Memory> Machine<M> {
 
 ```rust
 impl<M: Memory> Machine<M> {
-    fn eval_bin_op_int(&mut self, op: BinOpInt, left: BigInt, right: BigInt) -> NdResult<BigInt> {
+    fn eval_bin_op_int(&mut self, op: BinOpInt, left: Int, right: Int) -> NdResult<Int> {
         use BinOpInt::*;
         match op {
             Add => left + right,
@@ -96,7 +96,7 @@ impl<M: Memory> Machine<M> {
 ```rust
 impl<M: Memory> Machine<M> {
     /// Perform a wrapping offset on the given pointer. (Can never fail.)
-    fn ptr_offset_wrapping(&self, ptr: Pointer<M::Provenance>, offset: BigInt) -> Pointer<M::Provenance> {
+    fn ptr_offset_wrapping(&self, ptr: Pointer<M::Provenance>, offset: Int) -> Pointer<M::Provenance> {
         let offset = offset.modulo(Signed, M::PTR_SIZE);
         let addr = ptr.addr + offset;
         let addr = addr.modulo(Unsigned, M::PTR_SIZE);
@@ -105,7 +105,7 @@ impl<M: Memory> Machine<M> {
 
     /// Perform in-bounds arithmetic on the given pointer. This must not wrap,
     /// and the offset must stay in bounds of a single allocation.
-    fn ptr_offset_inbounds(&self, ptr: Pointer<M::Provenance>, offset: BigInt) -> NdResult<Pointer<M::Provenance>> {
+    fn ptr_offset_inbounds(&self, ptr: Pointer<M::Provenance>, offset: Int) -> NdResult<Pointer<M::Provenance>> {
         if !offset.in_bounds(Signed, M::PTR_SIZE) {
             throw_ub!("inbounds offset does not fit into `isize`");
         }

--- a/lang/step.md
+++ b/lang/step.md
@@ -403,7 +403,7 @@ impl<M: Memory> Machine<M> {
             locals,
             caller_ret_place,
             next_block: func.start,
-            next_stmt: BigInt::zero(),
+            next_stmt: BigInt::ZERO,
         });
     }
 }

--- a/lang/step.md
+++ b/lang/step.md
@@ -403,7 +403,7 @@ impl<M: Memory> Machine<M> {
             locals,
             caller_ret_place,
             next_block: func.start,
-            next_stmt: BigInt::ZERO,
+            next_stmt: Int::ZERO,
         });
     }
 }

--- a/lang/syntax.md
+++ b/lang/syntax.md
@@ -101,14 +101,14 @@ We also need to define constants (a strict subset of `Value`).
 /// Currently we do not support Ptr and Union constants.
 enum Constant {
     /// A mathematical integer, used for `i*`/`u*` types.
-    Int(BigInt),
+    Int(Int),
     /// A Boolean value, used for `bool`.
     Bool(bool),
     /// An n-tuple, used for arrays, structs, tuples (including unit).
     Tuple(List<Constant>),
     /// A variant of a sum type, used for enums.
     Variant {
-        idx: BigInt,
+        idx: Int,
         #[specr::indirection]
         data: Constant,
     },
@@ -204,7 +204,7 @@ enum PlaceExpr {
         #[specr::indirection]
         root: PlaceExpr,
         /// The field to project to.
-        field: BigInt,
+        field: Int,
     },
     /// Index to an array element.
     Index {

--- a/lang/types.md
+++ b/lang/types.md
@@ -43,7 +43,7 @@ enum Type {
     Array {
         #[specr::indirection]
         elem: Type,
-        count: BigInt,
+        count: Int,
     },
     Union {
         /// Fields *may* overlap. Fields only exist for field access place projections,

--- a/lang/values.md
+++ b/lang/values.md
@@ -15,7 +15,7 @@ The MiniRust value domain is described by the following type definition.
 ```rust
 enum Value<M: Memory> {
     /// A mathematical integer, used for `i*`/`u*` types.
-    Int(BigInt),
+    Int(Int),
     /// A Boolean value, used for `bool`.
     Bool(bool),
     /// A pointer value, used for (thin) references and raw pointers.
@@ -24,7 +24,7 @@ enum Value<M: Memory> {
     Tuple(List<Value<M>>),
     /// A variant of a sum type, used for enums.
     Variant {
-        idx: BigInt,
+        idx: Int,
         #[specr::indirection]
         data: Value<M>,
     },

--- a/lang/well-formed.md
+++ b/lang/well-formed.md
@@ -61,7 +61,7 @@ impl Type {
                 // The fields must not overlap.
                 // We check fields in the order of their (absolute) offsets.
                 fields.sort_by_key(|(offset, _ty)| offset);
-                let mut last_end = Size::zero();
+                let mut last_end = Size::ZERO;
                 for (offset, ty) in fields {
                     // Recursively check the field type.
                     ty.check_wf::<M>()?;
@@ -91,7 +91,7 @@ impl Type {
                 }
                 // The chunks must be sorted in their offsets and disjoint.
                 // FIXME: should we relax this and allow arbitrary chunk order?
-                let mut last_end = Size::zero();
+                let mut last_end = Size::ZERO;
                 for (offset, size) in chunks {
                     ensure(offset >= last_end)?;
                     last_end = offset + size;

--- a/mem/basic.md
+++ b/mem/basic.md
@@ -49,7 +49,7 @@ The model represents a 64-bit little-endian machine.
 
 ```rust
 impl Memory for BasicMemory {
-    const PTR_SIZE: Size = Size::from_bits(64);
+    const PTR_SIZE: Size = Size::from_bits_const(64);
     const ENDIANNESS: Endianness = LittleEndian;
 }
 ```

--- a/mem/basic.md
+++ b/mem/basic.md
@@ -13,7 +13,7 @@ The provenance tracked by this memory model is just an ID that identifies which 
 (We will pretend we can split the `impl ... for` block into multiple smaller blocks.)
 
 ```rust
-struct AllocId(BigInt);
+struct AllocId(Int);
 
 impl Memory for BasicMemory {
     type Provenance = AllocId;
@@ -28,7 +28,7 @@ struct Allocation {
     data: List<AbstractByte<AllocId>>,
     /// The address where this allocation starts.
     /// This is never 0, and `addr + data.len()` fits into a `usize`.
-    addr: BigInt,
+    addr: Int,
     /// The alignment that was requested for this allocation.
     /// `addr` will be a multiple of this.
     align: Align,
@@ -62,7 +62,7 @@ We start with some helper operations.
 impl Allocation {
     fn size(self) -> Size { Size::from_bytes(self.data.len()) }
 
-    fn overlaps(self, other_addr: BigInt, other_size: Size) -> bool {
+    fn overlaps(self, other_addr: Int, other_size: Size) -> bool {
         let end_addr = self.addr + self.size().bytes();
         let other_end_addr = other_addr + other_size.bytes();
         if end_addr <= other_addr || other_end_addr <= self.addr {
@@ -88,7 +88,7 @@ impl Memory for BasicMemory {
         // meaning the program has to cope with every possible choice.
         // FIXME: This makes OOM (when there is no possible choice) into "no behavior",
         // which is not what we want.
-        let addr = pick(|addr: BigInt| {
+        let addr = pick(|addr: Int| {
             // Pick a strictly positive integer...
             if addr <= 0 { return false; }
             // ... that is suitably aligned...

--- a/mem/interface.md
+++ b/mem/interface.md
@@ -66,7 +66,7 @@ The MiniRust memory interface is described by the following (not-yet-complete) t
 /// location in the real program.
 /// We make it a mathematical integer, but of course it is bounded by the size
 /// of the address space.
-type Address = BigInt;
+type Address = Int;
 
 /// A "pointer" is an address together with its Provenance.
 /// Provenance can be absent; those pointers are

--- a/mem/intptrcast.md
+++ b/mem/intptrcast.md
@@ -16,7 +16,7 @@ pub struct IntPtrCast<Provenance> {
 }
 
 impl<Provenance> IntPtrCast<Provenance> {
-    pub fn ptr2int(&mut self, ptr: Pointer<Provenance>) -> Result<BigInt> {
+    pub fn ptr2int(&mut self, ptr: Pointer<Provenance>) -> Result<Int> {
         if let Some(provenance) = ptr.provenance {
             // Remember this provenance as having been exposed.
             self.exposed.insert(provenance);
@@ -24,7 +24,7 @@ impl<Provenance> IntPtrCast<Provenance> {
         ptr.addr
     }
 
-    pub fn int2ptr(&mut self, addr: BigInt) -> NdResult<Pointer<Provenance>> {
+    pub fn int2ptr(&mut self, addr: Int) -> NdResult<Pointer<Provenance>> {
         // Predict a suitable provenance. It must be either `None` or already exposed.
         let provenance = predict(|prov: Option<Provenance>| {
             prov.map_or(

--- a/prelude/align.md
+++ b/prelude/align.md
@@ -8,9 +8,7 @@ See [Align](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_target/abi/str
 pub struct Align { raw: BigInt }
 
 impl Align {
-    pub fn one() -> Align {
-        Align { raw: BigInt::from(1) }
-    }
+    pub const ONE: Align = Align { raw: BigInt::ONE };
 
     /// align is rounded up to the next power of two.
     pub fn from_bytes(align: impl Into<BigInt>) -> Align {

--- a/prelude/align.md
+++ b/prelude/align.md
@@ -5,20 +5,20 @@ See [Align](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_target/abi/str
 
 ```rust
 /// `raw` stores the align in bytes.
-pub struct Align { raw: BigInt }
+pub struct Align { raw: Int }
 
 impl Align {
-    pub const ONE: Align = Align { raw: BigInt::ONE };
+    pub const ONE: Align = Align { raw: Int::ONE };
 
     /// align is rounded up to the next power of two.
-    pub fn from_bytes(align: impl Into<BigInt>) -> Align {
+    pub fn from_bytes(align: impl Into<Int>) -> Align {
         let align = align.into();
         let raw = align.next_power_of_two();
 
         Align { raw }
     }
 
-    pub fn bytes(self) -> BigInt {
+    pub fn bytes(self) -> Int {
         self.raw
     }
 }

--- a/prelude/endianness.md
+++ b/prelude/endianness.md
@@ -11,10 +11,10 @@ pub use Endianness::*;
 
 impl Endianness {
     /// If `signed == Signed`, the data is interpreted as two's complement.
-    pub fn decode(self, signed: Signedness, bytes: List<u8>) -> BigInt;
+    pub fn decode(self, signed: Signedness, bytes: List<u8>) -> Int;
 
     /// This can fail (return `None`) if the `int` does not fit into `size` bytes,
     /// or if it is negative and `signed == Unsigned`.
-    pub fn encode(self, signed: Signedness, size: Size, int: BigInt) -> Option<List<u8>>;
+    pub fn encode(self, signed: Signedness, size: Size, int: Int) -> Option<List<u8>>;
 }
 ```

--- a/prelude/int.md
+++ b/prelude/int.md
@@ -1,36 +1,36 @@
-BigInt is the type of mathematical integers.
+Int is the type of mathematical integers.
 
 We assume all the usual arithmetic operations to be defined.
-Additionally, BigInt provides a few utility functions.
+Additionally, Int provides a few utility functions.
 
 ```rust
-pub use specr::BigInt;
+pub use specr::Int;
 
-impl BigInt {
-    /// Converts any integer type to BigInt.
-    pub fn from(x: impl Into<BigInt>) -> BigInt;
+impl Int {
+    /// Converts any integer type to Int.
+    pub fn from(x: impl Into<Int>) -> Int;
 
     /// Returns the next-higher power of two.
-    pub fn next_power_of_two(&self) -> BigInt;
+    pub fn next_power_of_two(&self) -> Int;
 
     /// Checks whether `self` is a power of two.
     pub fn is_power_of_two(&self) -> bool;
 
     /// Computes `self / other`, returns None if `other` is zero.
-    pub fn checked_div(other: impl Into<BigInt>) -> Option<BigInt>;
+    pub fn checked_div(other: impl Into<Int>) -> Option<Int>;
 
     /// Returns the unique value that is equal to `self` modulo `2^size.bits()`.
     /// If `signed == Unsigned`, the result is in the interval `0..2^size.bits()`,
     /// else it is in the interval `-2^(size.bits()-1) .. 2^(size.bits()-1)`.
     ///
     /// `size` must not be zero.
-    pub fn modulo(self, signed: Signedness, size: Size) -> BigInt {
+    pub fn modulo(self, signed: Signedness, size: Size) -> Int {
         if size.is_zero() {
-            panic!("BigInt::modulo received invalid size zero!");
+            panic!("Int::modulo received invalid size zero!");
         }
 
         // the modulus.
-        let m = BigInt::from(2).pow(size.bits());
+        let m = Int::from(2).pow(size.bits());
 
         // n is in range `-(m-1)..m`.
         let n = self % m;

--- a/prelude/size.md
+++ b/prelude/size.md
@@ -11,9 +11,7 @@ Users needs check whether a given `Size` is too large for their Machine themselv
 pub struct Size { raw: BigInt }
 
 impl Size {
-    pub fn zero() -> Size {
-        Size { raw: BigInt::from(0) }
-    }
+    pub const ZERO: Size = Size { raw: BigInt::ZERO };
 
     /// Rounds `bits` up to the next-higher byte boundary, if `bits` is
     /// not a multiple of 8.

--- a/prelude/size.md
+++ b/prelude/size.md
@@ -28,6 +28,14 @@ impl Size {
         Size { raw }
     }
 
+    /// variation of `from_bits` for const contexts.
+    /// Cannot fail since the input is unsigned.
+    pub const fn from_bits_const(bits: u64) -> Size {
+        let bytes = bits / 8 + ((bits % 8) + 7) / 8;
+        let raw = Int::from(bytes);
+        Size { raw }
+    }
+
     /// Will panic if `bytes` is negative.
     pub fn from_bytes(bytes: impl Into<Int>) -> Size {
         let bytes = bytes.into();
@@ -37,6 +45,13 @@ impl Size {
         }
 
         Size { raw: bytes }
+    }
+
+    /// variation of `from_bytes` for const contexts.
+    /// Cannot fail since the input is unsigned.
+    pub const fn from_bytes_const(bytes: u64) -> Size {
+        let raw = Int::from(bytes);
+        Size { raw }
     }
 
     pub fn bytes(self) -> Int { self.raw }

--- a/prelude/size.md
+++ b/prelude/size.md
@@ -8,15 +8,15 @@ Users needs check whether a given `Size` is too large for their Machine themselv
 
 ```rust
 /// `raw` stores the size in bytes.
-pub struct Size { raw: BigInt }
+pub struct Size { raw: Int }
 
 impl Size {
-    pub const ZERO: Size = Size { raw: BigInt::ZERO };
+    pub const ZERO: Size = Size { raw: Int::ZERO };
 
     /// Rounds `bits` up to the next-higher byte boundary, if `bits` is
     /// not a multiple of 8.
     /// Will panic if `bits` is negative.
-    pub fn from_bits(bits: impl Into<BigInt>) -> Size {
+    pub fn from_bits(bits: impl Into<Int>) -> Size {
         let bits = bits.into();
 
         if bits < 0 {
@@ -29,7 +29,7 @@ impl Size {
     }
 
     /// Will panic if `bytes` is negative.
-    pub fn from_bytes(bytes: impl Into<BigInt>) -> Size {
+    pub fn from_bytes(bytes: impl Into<Int>) -> Size {
         let bytes = bytes.into();
 
         if bytes < 0 {
@@ -39,7 +39,7 @@ impl Size {
         Size { raw: bytes }
     }
 
-    pub fn bytes(self) -> BigInt { self.raw }
-    pub fn bits(self) -> BigInt { self.raw * 8 }
+    pub fn bytes(self) -> Int { self.raw }
+    pub fn bits(self) -> Int { self.raw * 8 }
 }
 ```


### PR DESCRIPTION
I did this `const BigInt` thing, which allows for `Align::ONE`, `Size::ZERO` etc.
```rust
pub enum BigInt {
    Big(GcCow<ExtBigInt>),
    Small(i128),
}
```
(Btw, do we want to rename `BigInt` to `Int`?)