### PR TITLE
Align::from_* returns None in case the input is no power of two

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # Fixed `minirust-tooling` commit, we need to bump this occasionally.
-TOOLING_COMMIT="2954395"
+TOOLING_COMMIT="87eaebe"
 
 # where to check out the tooling
 TOOLING_DIR="$HOME/minirust-tooling"

--- a/lang/intrinsic.md
+++ b/lang/intrinsic.md
@@ -97,7 +97,9 @@ impl<M: Memory> Machine<M> {
         let Value::Int(align) = arguments[1] else {
             throw_ub!("invalid second argument to `Intrinsic::Allocate`");
         };
-        let align = Align::from_bytes(align);
+        let Some(align) = Align::from_bytes(align) else {
+            throw_ub!("invalid Align for `Intrinsic::Allocate`");
+        };
 
         let alloc = self.mem.allocate(size, align)?;
         let bytes = encode_ptr::<M>(alloc);
@@ -128,7 +130,9 @@ impl<M: Memory> Machine<M> {
         let Value::Int(align) = arguments[2] else {
             throw_ub!("invalid third argument to `Intrinsic::Deallocate`");
         };
-        let align = Align::from_bytes(align);
+        let Some(align) = Align::from_bytes(align) else {
+            throw_ub!("invalid Align for `Intrinsic::Deallocate`");
+        };
 
         self.mem.deallocate(ptr, size, align)?;
 

--- a/lang/intrinsic.md
+++ b/lang/intrinsic.md
@@ -98,7 +98,7 @@ impl<M: Memory> Machine<M> {
             throw_ub!("invalid second argument to `Intrinsic::Allocate`");
         };
         let Some(align) = Align::from_bytes(align) else {
-            throw_ub!("invalid Align for `Intrinsic::Allocate`");
+            throw_ub!("invalid alignment for `Intrinsic::Allocate`: not a power of 2");
         };
 
         let alloc = self.mem.allocate(size, align)?;
@@ -131,7 +131,7 @@ impl<M: Memory> Machine<M> {
             throw_ub!("invalid third argument to `Intrinsic::Deallocate`");
         };
         let Some(align) = Align::from_bytes(align) else {
-            throw_ub!("invalid Align for `Intrinsic::Deallocate`");
+            throw_ub!("invalid alignment for `Intrinsic::Deallocate`: not a power of 2");
         };
 
         self.mem.deallocate(ptr, size, align)?;

--- a/mem/basic.md
+++ b/mem/basic.md
@@ -50,7 +50,7 @@ The model represents a 64-bit little-endian machine.
 ```rust
 impl Memory for BasicMemory {
     const PTR_SIZE: Size = Size::from_bits_const(64);
-    const PTR_ALIGN: Align = Align::from_bits_const(64);
+    const PTR_ALIGN: Align = Align::from_bits_const(64).unwrap();
     const ENDIANNESS: Endianness = LittleEndian;
 }
 ```


### PR DESCRIPTION
Changes mirrored at https://github.com/memoryleak47/minirust-tooling/commit/87eaebe3f2ef0cff177f6855f507510ecd307cf8