### PR TITLE
Size::from_* returns Option

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # Fixed `minirust-tooling` commit, we need to bump this occasionally.
-TOOLING_COMMIT="87eaebe"
+TOOLING_COMMIT="02818a2"
 
 # where to check out the tooling
 TOOLING_DIR="$HOME/minirust-tooling"

--- a/lang/intrinsic.md
+++ b/lang/intrinsic.md
@@ -92,7 +92,9 @@ impl<M: Memory> Machine<M> {
         let Value::Int(size) = arguments[0] else {
             throw_ub!("invalid first argument to `Intrinsic::Allocate`");
         };
-        let size = Size::from_bytes(size);
+        let Some(size) = Size::from_bytes(size) else {
+            throw_ub!("invalid size for `Intrinsic::Allocate`: negative size");
+        };
 
         let Value::Int(align) = arguments[1] else {
             throw_ub!("invalid second argument to `Intrinsic::Allocate`");
@@ -125,7 +127,9 @@ impl<M: Memory> Machine<M> {
         let Value::Int(size) = arguments[1] else {
             throw_ub!("invalid second argument to `Intrinsic::Deallocate`");
         };
-        let size = Size::from_bytes(size);
+        let Some(size) = Size::from_bytes(size) else {
+            throw_ub!("invalid size for `Intrinsic::Deallocate`: negative size");
+        };
 
         let Value::Int(align) = arguments[2] else {
             throw_ub!("invalid third argument to `Intrinsic::Deallocate`");

--- a/lang/operator.md
+++ b/lang/operator.md
@@ -126,7 +126,7 @@ impl<M: Memory> Machine<M> {
         // `offset.abs()` will fit into a `Size` since we did the overflow check above.
         // FIXME: actually, it could be isize::MIN and then everything breaks? Is that
         // a valid offset?
-        self.mem.dereferenceable(min_ptr, Size::from_bytes(offset.abs()), Align::ONE)?;
+        self.mem.dereferenceable(min_ptr, Size::from_bytes(offset.abs()).unwrap(), Align::ONE)?;
         // If this check passed, we are good.
         ret(new_ptr)
     }

--- a/lang/types.md
+++ b/lang/types.md
@@ -125,7 +125,7 @@ impl Type {
         use Type::*;
         match self {
             Int(int_type) => int_type.size,
-            Bool => Size::from_bytes(1),
+            Bool => Size::from_bytes_const(1),
             Ptr(_) => M::PTR_SIZE,
             Tuple { size, .. } | Union { size, .. } | Enum { size, .. } => size,
             Array { elem, count } => elem.size::<M>() * count,

--- a/mem/basic.md
+++ b/mem/basic.md
@@ -49,7 +49,7 @@ The model represents a 64-bit little-endian machine.
 
 ```rust
 impl Memory for BasicMemory {
-    const PTR_SIZE: Size = Size::from_bits_const(64);
+    const PTR_SIZE: Size = Size::from_bits_const(64).unwrap();
     const PTR_ALIGN: Align = Align::from_bits_const(64).unwrap();
     const ENDIANNESS: Endianness = LittleEndian;
 }
@@ -69,7 +69,7 @@ We start with some helper operations.
 
 ```rust
 impl Allocation {
-    fn size(self) -> Size { Size::from_bytes(self.data.len()) }
+    fn size(self) -> Size { Size::from_bytes(self.data.len()).unwrap() }
 
     fn overlaps(self, other_addr: Int, other_size: Size) -> bool {
         let end_addr = self.addr + self.size().bytes();
@@ -204,7 +204,7 @@ impl BasicMemory {
             throw_ub!("out-of-bounds memory access");
         }
         // All is good!
-        ret(Some((id, Size::from_bytes(offset_in_alloc))))
+        ret(Some((id, Size::from_bytes(offset_in_alloc).unwrap())))
     }
 }
 
@@ -220,7 +220,7 @@ impl Memory for BasicMemory {
     }
 
     fn store(&mut self, ptr: Pointer<Self::Provenance>, bytes: List<AbstractByte<Self::Provenance>>, align: Align) -> Result {
-        let size = Size::from_bytes(bytes.len());
+        let size = Size::from_bytes(bytes.len()).unwrap();
         let Some((id, offset)) = self.check_ptr(ptr, size, align)? else {
             return ret(());
         };


### PR DESCRIPTION
Size::from_* also previously had a panic if the input is negative.
Good that we caught that now, as this would have caused a panic with allocate / deallocate.

Annoying thing is that we end up having quite a few more unwraps.