### PR TITLE
Evaluate return place expressions in calls before other expressions

### DIFF
--- a/spec/lang/step.md
+++ b/spec/lang/step.md
@@ -426,6 +426,7 @@ impl<M: Memory> Machine<M> {
             ret::<NdResult<_>>((p, pty))
         })?;
 
+        // Then evaluate the function that will be called.
         let Value::Ptr(ptr) = self.eval_value(callee)? else {
             panic!("call on a non-pointer")
         };


### PR DESCRIPTION
I think this is the intended order, based on the comments as they stood before PR 100.

If this isn't the intended order, then I think at least the comment in the `CallIntrinsic` case needs moving.
