### PR TITLE
Atomic operations

### DIFF
--- a/spec/lang/intrinsic.md
+++ b/spec/lang/intrinsic.md
@@ -238,7 +238,7 @@ impl<M: Memory> Machine<M> {
 }
 ```
 
-The intrinsics for atomic memory accesses
+These are the intrinsics for atomic memory accesses:
 
 ```rust
 impl<M: Memory> Machine<M> {
@@ -265,14 +265,14 @@ impl<M: Memory> Machine<M> {
         }
 
         if size > M::MAX_ATOMIC_SIZE {
-            throw_ub!("invalid second argument to `Intrinsic::AtomicWrite`, size to big");
+            throw_ub!("invalid second argument to `Intrinsic::AtomicWrite`, size too big");
         }
 
         if !is_unit(ret_ty) {
             throw_ub!("invalid return type for `Intrinsic::AtomicWrite`")
         }
         
-        let pty = PlaceType{ty, align: Align::max_for_offset(size).unwrap()};
+        let pty = PlaceType { ty, align: Align::max_for_offset(size).unwrap() };
 
         self.mem.typed_store(Atomicity::Atomic, ptr, val, pty)?;
 
@@ -300,7 +300,7 @@ impl<M: Memory> Machine<M> {
         }
 
         if size > M::MAX_ATOMIC_SIZE {
-            throw_ub!("invalid return type for `Intrinsic::AtomicRead`, size to big");
+            throw_ub!("invalid return type for `Intrinsic::AtomicRead`, size too big");
         }
 
         let pty = PlaceType{ty: ret_ty, align: Align::max_for_offset(size).unwrap()};

--- a/spec/lang/intrinsic.md
+++ b/spec/lang/intrinsic.md
@@ -6,7 +6,7 @@ impl<M: Memory> Machine<M> {
     fn eval_intrinsic(
         &mut self,
         intrinsic: Intrinsic,
-        arguments: List<(Value<M>,Type)>,
+        arguments: List<(Value<M>, Type)>,
         ret_ty: Type,
     ) -> NdResult<Value<M>> { .. }
 }
@@ -39,7 +39,7 @@ impl<M: Memory> Machine<M> {
     fn eval_intrinsic(
         &mut self,
         Intrinsic::Exit: Intrinsic,
-        arguments: List<(Value<M>,Type)>,
+        arguments: List<(Value<M>, Type)>,
         ret_ty: Type,
     ) -> NdResult<Value<M>> {
         throw_machine_stop!()
@@ -54,7 +54,7 @@ impl<M: Memory> Machine<M> {
     fn eval_intrinsic(
         &mut self,
         Intrinsic::PrintStdout: Intrinsic,
-        arguments: List<(Value<M>,Type)>,
+        arguments: List<(Value<M>, Type)>,
         ret_ty: Type,
     ) -> NdResult<Value<M>> {
         if !is_unit(ret_ty) {
@@ -69,7 +69,7 @@ impl<M: Memory> Machine<M> {
     fn eval_intrinsic(
         &mut self,
         Intrinsic::PrintStderr: Intrinsic,
-        arguments: List<(Value<M>,Type)>,
+        arguments: List<(Value<M>, Type)>,
         ret_ty: Type,
     ) -> NdResult<Value<M>> {
         if !is_unit(ret_ty) {
@@ -84,7 +84,7 @@ impl<M: Memory> Machine<M> {
     fn eval_print(
         &mut self,
         stream: DynWrite,
-        arguments: List<(Value<M>,Type)>,
+        arguments: List<(Value<M>, Type)>,
     ) -> Result {
         for (arg, _) in arguments {
             match arg {
@@ -106,7 +106,7 @@ impl<M: Memory> Machine<M> {
     fn eval_intrinsic(
         &mut self,
         Intrinsic::Allocate: Intrinsic,
-        arguments: List<(Value<M>,Type)>,
+        arguments: List<(Value<M>, Type)>,
         ret_ty: Type,
     ) -> NdResult<Value<M>> {
         if arguments.len() != 2 {
@@ -139,7 +139,7 @@ impl<M: Memory> Machine<M> {
     fn eval_intrinsic(
         &mut self,
         Intrinsic::Deallocate: Intrinsic,
-        arguments: List<(Value<M>,Type)>,
+        arguments: List<(Value<M>, Type)>,
         ret_ty: Type,
     ) -> NdResult<Value<M>> {
         if arguments.len() != 3 {
@@ -182,7 +182,7 @@ impl<M: Memory> Machine<M> {
     fn eval_intrinsic(
         &mut self,
         Intrinsic::Spawn: Intrinsic,
-        arguments: List<(Value<M>,Type)>,
+        arguments: List<(Value<M>, Type)>,
         ret_ty: Type,
     ) -> NdResult<Value<M>> {
         if arguments.len() != 1 {
@@ -216,7 +216,7 @@ impl<M: Memory> Machine<M> {
     fn eval_intrinsic(
         &mut self,
         Intrinsic::Join: Intrinsic,
-        arguments: List<(Value<M>,Type)>,
+        arguments: List<(Value<M>, Type)>,
         ret_ty: Type,
     ) -> NdResult<Value<M>> {
         if arguments.len() != 1 {
@@ -245,7 +245,7 @@ impl<M: Memory> Machine<M> {
     fn eval_intrinsic(
         &mut self,
         Intrinsic::AtomicWrite: Intrinsic,
-        arguments: List<(Value<M>,Type)>,
+        arguments: List<(Value<M>, Type)>,
         ret_ty: Type,
     ) -> NdResult<Value<M>> {
         if arguments.len() != 2 {
@@ -282,7 +282,7 @@ impl<M: Memory> Machine<M> {
     fn eval_intrinsic(
         &mut self,
         Intrinsic::AtomicRead: Intrinsic,
-        arguments: List<(Value<M>,Type)>,
+        arguments: List<(Value<M>, Type)>,
         ret_ty: Type,
     ) -> NdResult<Value<M>> {
         if arguments.len() != 1 {

--- a/spec/lang/intrinsic.md
+++ b/spec/lang/intrinsic.md
@@ -271,7 +271,7 @@ impl<M: Memory> Machine<M> {
         if !is_unit(ret_ty) {
             throw_ub!("invalid return type for `Intrinsic::AtomicWrite`")
         }
-        
+       
         let pty = PlaceType { ty, align: Align::max_for_offset(size).unwrap() };
 
         self.mem.typed_store(Atomicity::Atomic, ptr, val, pty)?;

--- a/spec/lang/intrinsic.md
+++ b/spec/lang/intrinsic.md
@@ -271,8 +271,8 @@ impl<M: Memory> Machine<M> {
         if !is_unit(ret_ty) {
             throw_ub!("invalid return type for `Intrinsic::AtomicWrite`")
         }
-       
-        let pty = PlaceType { ty, align: Align::max_for_offset(size).unwrap() };
+
+        let pty = PlaceType { ty, align: Align::from_bytes(size.bytes()).unwrap() };
 
         self.mem.typed_store(Atomicity::Atomic, ptr, val, pty)?;
 

--- a/spec/lang/intrinsic.md
+++ b/spec/lang/intrinsic.md
@@ -303,7 +303,7 @@ impl<M: Memory> Machine<M> {
             throw_ub!("invalid return type for `Intrinsic::AtomicRead`, size too big");
         }
 
-        let pty = PlaceType{ty: ret_ty, align: Align::max_for_offset(size).unwrap()};
+        let pty = PlaceType { ty: ret_ty, align: Align::max_for_offset(size).unwrap() };
 
         let val = self.mem.typed_load(Atomicity::Atomic, ptr, pty)?;
 

--- a/spec/lang/intrinsic.md
+++ b/spec/lang/intrinsic.md
@@ -251,19 +251,15 @@ impl<M: Memory> Machine<M> {
         if arguments.len() != 2 {
             throw_ub!("invalid number of arguments for `Intrinsic::AtomicWrite`");
         }
-
         let Value::Ptr(ptr) = arguments[0].0 else {
             throw_ub!("invalid first argument to `Intrinsic::AtomicWrite`");
         };
-
         let (val, ty) = arguments[1];
 
         let size = ty.size::<M>();
-
         if !size.bytes().is_power_of_two() {
             throw_ub!("invalid second argument to `Intrinsic::AtomicWrite`, size not power of two");
         }
-
         if size > M::MAX_ATOMIC_SIZE {
             throw_ub!("invalid second argument to `Intrinsic::AtomicWrite`, size too big");
         }
@@ -273,9 +269,7 @@ impl<M: Memory> Machine<M> {
         }
 
         let pty = PlaceType { ty, align: Align::from_bytes(size.bytes()).unwrap() };
-
         self.mem.typed_store(Atomicity::Atomic, ptr, val, pty)?;
-
         ret(unit_value())
     }
 
@@ -288,25 +282,20 @@ impl<M: Memory> Machine<M> {
         if arguments.len() != 1 {
             throw_ub!("invalid number of arguments for `Intrinsic::AtomicRead`");
         }
-
         let Value::Ptr(ptr) = arguments[0].0 else {
             throw_ub!("invalid first argument to `Intrinsic::AtomicRead`");
         };
 
         let size = ret_ty.size::<M>();
-
         if !size.bytes().is_power_of_two() {
             throw_ub!("invalid return type for `Intrinsic::AtomicRead`, size not power of two");
         }
-
         if size > M::MAX_ATOMIC_SIZE {
             throw_ub!("invalid return type for `Intrinsic::AtomicRead`, size too big");
         }
 
-        let pty = PlaceType { ty: ret_ty, align: Align::max_for_offset(size).unwrap() };
-
+        let pty = PlaceType { ty: ret_ty, align: Align::from_bytes(size.bytes()).unwrap() };
         let val = self.mem.typed_load(Atomicity::Atomic, ptr, pty)?;
-
         ret(val)
     }
 }

--- a/spec/lang/locks.md
+++ b/spec/lang/locks.md
@@ -116,7 +116,7 @@ impl<M: Memory> Machine<M> {
     fn eval_intrinsic(
         &mut self,
         Intrinsic::Lock(LockIntrinsic::Create): Intrinsic,
-        arguments: List<Value<M>>,
+        arguments: List<(Value<M>, Type)>,
         ret_ty: Type,
     ) -> NdResult<Value<M>> {
         if arguments.len() > 0 {
@@ -141,14 +141,14 @@ impl<M: Memory> Machine<M> {
     fn eval_intrinsic(
         &mut self,
         Intrinsic::Lock(LockIntrinsic::Acquire): Intrinsic,
-        arguments: List<Value<M>>,
+        arguments: List<(Value<M>, Type)>,
         ret_ty: Type,
     ) -> NdResult<Value<M>> {
         if arguments.len() != 1 {
             throw_ub!("invalid number of arguments for `LockIntrinsic::Acquire`");
         }
 
-        let Value::Int(lock_id) = arguments[0] else {
+        let Value::Int(lock_id) = arguments[0].0 else {
             throw_ub!("invalid first argument to `LockIntrinsic::Acquire`");
         };
 
@@ -170,14 +170,14 @@ impl<M: Memory> Machine<M> {
     fn eval_intrinsic(
         &mut self,
         Intrinsic::Lock(LockIntrinsic::Release): Intrinsic,
-        arguments: List<Value<M>>,
+        arguments: List<(Value<M>, Type)>,
         ret_ty: Type,
     ) -> NdResult<Value<M>> {
         if arguments.len() != 1 {
             throw_ub!("invalid number of arguments for `LockIntrinsic::Release`");
         }
 
-        let Value::Int(lock_id) = arguments[0] else {
+        let Value::Int(lock_id) = arguments[0].0 else {
             throw_ub!("invalid first argument to `LockIntrinsic::Release`");
         };
 

--- a/spec/lang/machine.md
+++ b/spec/lang/machine.md
@@ -14,7 +14,7 @@ pub struct Machine<M: Memory> {
     prog: Program,
 
     /// The state of memory.
-    mem: M,
+    mem: AtomicMemory<M>,
 
     /// The state of the integer-pointer cast subsystem.
     intptrcast: IntPtrCast<M::Provenance>,
@@ -115,7 +115,7 @@ impl<M: Memory> Machine<M> {
             throw_ill_formed!();
         }
 
-        let mut mem = M::new();
+        let mut mem = AtomicMemory::<M>::new();
         let mut global_ptrs = Map::new();
         let mut fn_addrs = Map::new();
 
@@ -139,7 +139,7 @@ impl<M: Memory> Machine<M> {
                 let encoded_ptr = encode_ptr::<M>(ptr);
                 bytes.write_subslice_at_index(i.bytes(), encoded_ptr);
             }
-            mem.store(global_ptrs[global_name], bytes, global.align)?;
+            mem.store(Atomicity::None, global_ptrs[global_name], bytes, global.align)?;
         }
 
         // Allocate functions.

--- a/spec/lang/prelude.md
+++ b/spec/lang/prelude.md
@@ -4,7 +4,7 @@ For the files in this folder, we assume some definitions and parameters to alway
 
 ```rust
 use crate::prelude::*;
-use mem::{Memory, AbstractByte, Pointer, IntPtrCast};
+use mem::{Memory, AbstractByte, Pointer, IntPtrCast, AtomicMemory, Atomicity};
 
 // Everything there is to say about how an argument is passed to a function,
 // and how the return value is passed back.

--- a/spec/lang/step.md
+++ b/spec/lang/step.md
@@ -577,7 +577,7 @@ impl<M: Memory> Machine<M> {
         let ret_place = ret_expr.try_map(|ret_expr| self.eval_place(ret_expr))?;
 
         // Evaluate all arguments.
-        let arguments = arguments.try_map(|arg| self.eval_value(arg))?.map(|e| e.0);
+        let arguments = arguments.try_map(|arg| self.eval_value(arg))?;
 
         let ret_ty = ret_place.map(|(_, pty)| pty.ty).unwrap_or_else(|| unit_type());
 

--- a/spec/lang/step.md
+++ b/spec/lang/step.md
@@ -132,10 +132,10 @@ This loads a value from a place (often called "place-to-value coercion").
 impl<M: Memory> Machine<M> {
     fn eval_value(&mut self, ValueExpr::Load { destructive, source }: ValueExpr) -> NdResult<(Value<M>, Type)> {
         let (p, ptype) = self.eval_place(source)?;
-        let v = self.mem.typed_load(Atomicity::Default, p, ptype)?;
+        let v = self.mem.typed_load(Atomicity::None, p, ptype)?;
         if destructive {
             // Overwrite the source with `Uninit`.
-            self.mem.store(Atomicity::Default, p, list![AbstractByte::Uninit; ptype.ty.size::<M>().bytes()], ptype.align)?;
+            self.mem.store(Atomicity::None, p, list![AbstractByte::Uninit; ptype.ty.size::<M>().bytes()], ptype.align)?;
         }
 
         ret((v, ptype.ty))
@@ -318,7 +318,7 @@ impl<M: Memory> Machine<M> {
     fn eval_statement(&mut self, Statement::Assign { destination, source }: Statement) -> NdResult {
         let (place, ptype) = self.eval_place(destination)?;
         let (val, _) = self.eval_value(source)?;
-        self.mem.typed_store(Atomicity::Default, place, val, ptype)?;
+        self.mem.typed_store(Atomicity::None, place, val, ptype)?;
 
         ret(())
     }
@@ -336,9 +336,9 @@ impl<M: Memory> Machine<M> {
     fn eval_statement(&mut self, Statement::Finalize { place, fn_entry }: Statement) -> NdResult {
         let (p, ptype) = self.eval_place(place)?;
 
-        let val = self.mem.typed_load(Atomicity::Default, p, ptype)?;
+        let val = self.mem.typed_load(Atomicity::None, p, ptype)?;
         let val = self.mem.retag_val(val, ptype.ty, fn_entry)?;
-        self.mem.typed_store(Atomicity::Default, p, val, ptype)?;
+        self.mem.typed_store(Atomicity::None, p, val, ptype)?;
 
         ret(())
     }
@@ -486,7 +486,7 @@ impl<M: Memory> Machine<M> {
             // Store value with caller type (otherwise we could get panics).
             // The ABI above should ensure that this does not go OOB,
             // and it is a fresh pointer so there should be no other reason this can fail.
-            self.mem.typed_store(Atomicity::Default, p, val, PlaceType::new(caller_ty, callee_layout.align)).unwrap();
+            self.mem.typed_store(Atomicity::None, p, val, PlaceType::new(caller_ty, callee_layout.align)).unwrap();
             locals.insert(local, p);
         }
 
@@ -538,8 +538,8 @@ impl<M: Memory> Machine<M> {
         // On the other hand, the callee is done here, so why would it even still
         // care about the return value?
         if let Some((ret_place, ret_pty)) = caller_return_info.ret_place {
-            let ret_val = self.mem.typed_load(Atomicity::Default, frame.locals[ret_local], ret_pty)?;
-            self.mem.typed_store(Atomicity::Default, ret_place, ret_val, ret_pty)?;
+            let ret_val = self.mem.typed_load(Atomicity::None, frame.locals[ret_local], ret_pty)?;
+            self.mem.typed_store(Atomicity::None, ret_place, ret_val, ret_pty)?;
         }
 
         // Deallocate everything.
@@ -585,7 +585,7 @@ impl<M: Memory> Machine<M> {
 
         if let Some((ret_place, ret_pty)) = ret_place {
             // `eval_inrinsic` above must guarantee that `value` has the right type.
-            self.mem.typed_store(Atomicity::Default, ret_place, value, ret_pty)?;
+            self.mem.typed_store(Atomicity::None, ret_place, value, ret_pty)?;
         }
             
         if let Some(next_block) = next_block {

--- a/spec/lang/step.md
+++ b/spec/lang/step.md
@@ -587,7 +587,7 @@ impl<M: Memory> Machine<M> {
             // `eval_inrinsic` above must guarantee that `value` has the right type.
             self.mem.typed_store(Atomicity::None, ret_place, value, ret_pty)?;
         }
-            
+
         if let Some(next_block) = next_block {
             self.mutate_cur_frame(|frame| {
                 frame.jump_to_block(next_block);

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -130,6 +130,8 @@ pub enum Intrinsic {
     Deallocate,
     Spawn,
     Join,
+    AtomicWrite,
+    AtomicRead,
     Lock(LockIntrinsic),
 }
 ```

--- a/spec/lang/values.md
+++ b/spec/lang/values.md
@@ -466,7 +466,7 @@ impl<M: Memory> AtomicMemory<M> {
             _ => panic!("this value does not have that type"),
         })
     }
-}  
+}
 ```
 
 ## Relation to validity invariant

--- a/spec/lang/values.md
+++ b/spec/lang/values.md
@@ -423,39 +423,24 @@ This interface is inspired by [Cerberus](https://www.cl.cam.ac.uk/~pes20/cerberu
 We also use this to lift retagging from pointers to compound values.
 
 ```rust
-trait TypedMemory: Memory {
-    /// Write a value of the given type to memory.
-    /// Note that it is a spec bug if `val` cannot be encoded at `ty`!
-    fn typed_store(&mut self, ptr: Pointer<Self::Provenance>, val: Value<Self>, pty: PlaceType) -> Result;
-
-    /// Read a value of the given type.
-    fn typed_load(&mut self, ptr: Pointer<Self::Provenance>, pty: PlaceType) -> Result<Value<Self>>;
-
-    /// Check that the given pointer is dereferenceable according to the given layout.
-    fn layout_dereferenceable(&self, ptr: Pointer<Self::Provenance>, layout: Layout) -> Result;
-
-    /// Retag all pointers inside this value.
-    fn retag_val(&mut self, val: Value<Self>, ty: Type, fn_entry: bool) -> Result<Value<Self>>;
-}
-
-impl<M: Memory> TypedMemory for M {
-    fn typed_store(&mut self, ptr: Pointer<Self::Provenance>, val: Value<Self>, pty: PlaceType) -> Result {
-        let bytes = pty.ty.encode::<Self>(val);
-        self.store(ptr, bytes, pty.align)?;
+impl<M: Memory> AtomicMemory<M> {
+    fn typed_store(&mut self, atomicity: Atomicity, ptr: Pointer<M::Provenance>, val: Value<M>, pty: PlaceType) -> Result {
+        let bytes = pty.ty.encode::<M>(val);
+        self.store(atomicity, ptr, bytes, pty.align)?;
 
         ret(())
     }
 
-    fn typed_load(&mut self, ptr: Pointer<Self::Provenance>, pty: PlaceType) -> Result<Value<Self>> {
-        let bytes = self.load(ptr, pty.ty.size::<Self>(), pty.align)?;
-        ret(match pty.ty.decode::<Self>(bytes) {
+    fn typed_load(&mut self, atomicity: Atomicity, ptr: Pointer<M::Provenance>, pty: PlaceType) -> Result<Value<M>> {
+        let bytes = self.load(atomicity, ptr, pty.ty.size::<M>(), pty.align)?;
+        ret(match pty.ty.decode::<M>(bytes) {
             Some(val) => val,
             None => throw_ub!("load at type {pty:?} but the data in memory violates the validity invariant"), // FIXME use Display instead of Debug for `pty`
         })
     }
 
     // FIXME this method is currently unused.
-    fn layout_dereferenceable(&self, ptr: Pointer<Self::Provenance>, layout: Layout) -> Result {
+    fn _layout_dereferenceable(&self, ptr: Pointer<M::Provenance>, layout: Layout) -> Result {
         if !layout.inhabited {
             // TODO: I don't think Miri does this check.
             throw_ub!("uninhabited types are not dereferenceable");
@@ -465,7 +450,7 @@ impl<M: Memory> TypedMemory for M {
         ret(())
     }
 
-    fn retag_val(&mut self, val: Value<Self>, ty: Type, fn_entry: bool) -> Result<Value<Self>> {
+    fn retag_val(&mut self, val: Value<M>, ty: Type, fn_entry: bool) -> Result<Value<M>> {
         ret(match (val, ty) {
             // no (identifiable) pointers
             (Value::Int(..) | Value::Bool(..) | Value::Union(..), _) => val,
@@ -481,7 +466,7 @@ impl<M: Memory> TypedMemory for M {
             _ => panic!("this value does not have that type"),
         })
     }
-}
+}  
 ```
 
 ## Relation to validity invariant

--- a/spec/mem/atomic.md
+++ b/spec/mem/atomic.md
@@ -1,14 +1,15 @@
 # MiniRust atomic memory
 
-This is a wrapper for a memory. It is used by the machine to distinguish between non-atomic and atomic memory accesses.
+This is a wrapper for a memory that distinguishes between non-atomic and atomic memory accesses.
 
 ```rust
-pub struct AtomicMemory<M: Memory>{
+pub struct AtomicMemory<M: Memory> {
     memory: M,
 }
 
-/// The different kind of atomicity
+/// The different kinds of atomicity.
 pub enum Atomicity {
+    /// A sequentially consistent atomic access.
     Atomic,
     Default,
 

--- a/spec/mem/atomic.md
+++ b/spec/mem/atomic.md
@@ -1,6 +1,7 @@
 # MiniRust atomic memory
 
-This is a wrapper for a memory that distinguishes between non-atomic and atomic memory accesses. For now atomicity is ignored; this will change in the future/
+This is a wrapper for a memory that distinguishes between non-atomic and atomic memory accesses.
+For now atomicity is ignored; this will change in the future.
 
 ```rust
 pub struct AtomicMemory<M: Memory> {

--- a/spec/mem/atomic.md
+++ b/spec/mem/atomic.md
@@ -1,0 +1,63 @@
+# MiniRust atomic memory
+
+This is a wrapper for a memory. It is used by the machine to distinguish between non-atomic and atomic memory accesses.
+
+```rust
+pub struct AtomicMemory<M: Memory>{
+    memory: M,
+}
+
+/// The different kind of atomicity
+pub enum Atomicity {
+    Atomic,
+    Default,
+
+    /// Not at run-time
+    None,
+}
+
+impl<M: Memory> AtomicMemory<M> {
+    pub fn new() -> Self {
+        Self{memory: M::new()}
+    }
+
+    /// Create a new allocation.
+    /// The initial contents of the allocation are `AbstractByte::Uninit`.
+    pub fn allocate(&mut self, size: Size, align: Align) -> NdResult<Pointer<M::Provenance>> {
+        self.memory.allocate(size, align)
+    }
+
+    /// Remove an allocation.
+    pub fn deallocate(&mut self, ptr: Pointer<M::Provenance>, size: Size, align: Align) -> Result {
+        self.memory.deallocate(ptr, size, align)
+    }
+
+    /// Write some bytes to memory.
+    pub fn store(&mut self, _atomicity: Atomicity, ptr: Pointer<M::Provenance>, bytes: List<AbstractByte<M::Provenance>>, align: Align) -> Result {
+        self.memory.store(ptr, bytes, align)
+    }
+
+    /// Read some bytes from memory.
+    pub fn load(&mut self, _atomicity: Atomicity, ptr: Pointer<M::Provenance>, len: Size, align: Align) -> Result<List<AbstractByte<M::Provenance>>>{
+        self.memory.load(ptr, len, align)
+    }
+
+    /// Test whether the given pointer is dereferenceable for the given size and alignment.
+    /// Raises UB if that is not the case.
+    /// Note that a successful read/write/deallocate implies that the pointer
+    /// was dereferenceable before that operation (but not vice versa).
+    pub fn dereferenceable(&self, ptr: Pointer<M::Provenance>, size: Size, align: Align) -> Result {
+        self.memory.dereferenceable(ptr, size, align)
+    }
+
+    /// Return the retagged pointer.
+    pub fn retag_ptr(&mut self, ptr: Pointer<M::Provenance>, ptr_type: lang::PtrType, fn_entry: bool) -> Result<Pointer<M::Provenance>> {
+        self.memory.retag_ptr(ptr, ptr_type, fn_entry)
+    }
+
+    /// Checks that `size` is not too large for the Memory.
+    pub fn valid_size(size: Size) -> bool {
+        M::valid_size(size)
+    }
+}
+```

--- a/spec/mem/atomic.md
+++ b/spec/mem/atomic.md
@@ -1,6 +1,6 @@
 # MiniRust atomic memory
 
-This is a wrapper for a memory that distinguishes between non-atomic and atomic memory accesses.
+This is a wrapper for a memory that distinguishes between non-atomic and atomic memory accesses. For now atomicity is ignored; this will change in the future/
 
 ```rust
 pub struct AtomicMemory<M: Memory> {

--- a/spec/mem/atomic.md
+++ b/spec/mem/atomic.md
@@ -19,7 +19,7 @@ pub enum Atomicity {
 
 impl<M: Memory> AtomicMemory<M> {
     pub fn new() -> Self {
-        Self{memory: M::new()}
+        Self { memory: M::new() }
     }
 
     /// Create a new allocation.
@@ -39,7 +39,7 @@ impl<M: Memory> AtomicMemory<M> {
     }
 
     /// Read some bytes from memory.
-    pub fn load(&mut self, _atomicity: Atomicity, ptr: Pointer<M::Provenance>, len: Size, align: Align) -> Result<List<AbstractByte<M::Provenance>>>{
+    pub fn load(&mut self, _atomicity: Atomicity, ptr: Pointer<M::Provenance>, len: Size, align: Align) -> Result<List<AbstractByte<M::Provenance>>> {
         self.memory.load(ptr, len, align)
     }
 

--- a/spec/mem/atomic.md
+++ b/spec/mem/atomic.md
@@ -11,9 +11,8 @@ pub struct AtomicMemory<M: Memory> {
 pub enum Atomicity {
     /// A sequentially consistent atomic access.
     Atomic,
-    Default,
 
-    /// Not at run-time
+    /// A non-atomic memory access.
     None,
 }
 

--- a/spec/mem/basic.md
+++ b/spec/mem/basic.md
@@ -52,6 +52,8 @@ impl Memory for BasicMemory {
     const PTR_SIZE: Size = Size::from_bits_const(64).unwrap();
     const PTR_ALIGN: Align = Align::from_bits_const(64).unwrap();
     const ENDIANNESS: Endianness = LittleEndian;
+
+    const MAX_ATOMIC_SIZE: Size = Size::from_bits_const(64).unwrap();
 }
 ```
 

--- a/spec/mem/interface.md
+++ b/spec/mem/interface.md
@@ -88,11 +88,11 @@ pub trait Memory {
     const PTR_SIZE: Size;
     const PTR_ALIGN: Align;
 
-    /// Maximum size of an atomic operation
-    const MAX_ATOMIC_SIZE: Size;
-
     /// The endianess used for encoding multi-byte integer values (and pointers).
     const ENDIANNESS: Endianness;
+
+    /// Maximum size of an atomic operation
+    const MAX_ATOMIC_SIZE: Size;
 
 
     fn new() -> Self;

--- a/spec/mem/interface.md
+++ b/spec/mem/interface.md
@@ -88,6 +88,9 @@ pub trait Memory {
     const PTR_SIZE: Size;
     const PTR_ALIGN: Align;
 
+    /// Maximum size of an atomic operation
+    const MAX_ATOMIC_SIZE: Size;
+
     /// The endianess used for encoding multi-byte integer values (and pointers).
     const ENDIANNESS: Endianness;
 

--- a/spec/mem/interface.md
+++ b/spec/mem/interface.md
@@ -91,7 +91,7 @@ pub trait Memory {
     /// The endianess used for encoding multi-byte integer values (and pointers).
     const ENDIANNESS: Endianness;
 
-    /// Maximum size of an atomic operation
+    /// Maximum size of an atomic operation.
     const MAX_ATOMIC_SIZE: Size;
 
 

--- a/tooling/minitest/src/ub/atomic.rs
+++ b/tooling/minitest/src/ub/atomic.rs
@@ -29,10 +29,10 @@ fn atomic_write_success() {
 #[test]
 fn atomic_write_arg_count() {
     let b0 = block!(
-        Terminator::CallIntrinsic { 
-            intrinsic: Intrinsic::AtomicWrite, 
-            arguments: list!(), 
-            ret: None, 
+        Terminator::CallIntrinsic {
+            intrinsic: Intrinsic::AtomicWrite,
+            arguments: list!(),
+            ret: None,
             next_block: Some(BbName(Name::from_internal(1)))
         }
     );
@@ -48,10 +48,10 @@ fn atomic_write_arg_count() {
 #[test]
 fn atomic_write_arg_type1() {
     let b0 = block!(
-        Terminator::CallIntrinsic { 
-            intrinsic: Intrinsic::AtomicWrite, 
-            arguments: list!(const_int::<u32>(0), const_int::<u32>(0)), 
-            ret: None, 
+        Terminator::CallIntrinsic {
+            intrinsic: Intrinsic::AtomicWrite,
+            arguments: list!(const_int::<u32>(0), const_int::<u32>(0)),
+            ret: None,
             next_block: Some(BbName(Name::from_internal(1)))
         }
     );
@@ -79,10 +79,10 @@ fn atomic_write_arg_type_pow() {
     let b0 = block!(
         storage_live(0),
 
-        Terminator::CallIntrinsic { 
-            intrinsic: Intrinsic::AtomicWrite, 
-            arguments: list!(addr_of(local(0), ptr_ty), arr), 
-            ret: None, 
+        Terminator::CallIntrinsic {
+            intrinsic: Intrinsic::AtomicWrite,
+            arguments: list!(addr_of(local(0), ptr_ty), arr),
+            ret: None,
             next_block: Some(BbName(Name::from_internal(1)))
         }
     );
@@ -110,10 +110,10 @@ fn atomic_write_arg_type_size() {
     let b0 = block!(
         storage_live(0),
 
-        Terminator::CallIntrinsic { 
-            intrinsic: Intrinsic::AtomicWrite, 
-            arguments: list!(addr_of(local(0), ptr_ty), arr), 
-            ret: None, 
+        Terminator::CallIntrinsic {
+            intrinsic: Intrinsic::AtomicWrite,
+            arguments: list!(addr_of(local(0), ptr_ty), arr),
+            ret: None,
             next_block: Some(BbName(Name::from_internal(1)))
         }
     );
@@ -135,10 +135,10 @@ fn atomic_write_ret_type() {
     let b0 = block!(
         storage_live(0),
 
-        Terminator::CallIntrinsic { 
-            intrinsic: Intrinsic::AtomicWrite, 
-            arguments: list!(addr_of(local(0), ptr_ty), const_int::<u64>(0)), 
-            ret: Some(local(0)), 
+        Terminator::CallIntrinsic {
+            intrinsic: Intrinsic::AtomicWrite,
+            arguments: list!(addr_of(local(0), ptr_ty), const_int::<u64>(0)),
+            ret: Some(local(0)),
             next_block: Some(BbName(Name::from_internal(1)))
         }
     );
@@ -184,10 +184,10 @@ fn atomic_read_arg_count() {
 
     let b0 = block!(
         storage_live(0),
-        Terminator::CallIntrinsic { 
-            intrinsic: Intrinsic::AtomicRead, 
-            arguments: list!(), 
-            ret: Some(local(0)), 
+        Terminator::CallIntrinsic {
+            intrinsic: Intrinsic::AtomicRead,
+            arguments: list!(),
+            ret: Some(local(0)),
             next_block: Some(BbName(Name::from_internal(1)))
         }
     );
@@ -206,10 +206,10 @@ fn atomic_read_arg_type() {
 
     let b0 = block!(
         storage_live(0),
-        Terminator::CallIntrinsic { 
-            intrinsic: Intrinsic::AtomicRead, 
-            arguments: list!(const_unit()), 
-            ret: Some(local(0)), 
+        Terminator::CallIntrinsic {
+            intrinsic: Intrinsic::AtomicRead,
+            arguments: list!(const_unit()),
+            ret: Some(local(0)),
             next_block: Some(BbName(Name::from_internal(1)))
         }
     );

--- a/tooling/minitest/src/ub/atomic.rs
+++ b/tooling/minitest/src/ub/atomic.rs
@@ -22,7 +22,6 @@ fn atomic_write_success() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2, b3]);
     let p = program(&[f]);
-
     assert_stop(p);
 }
 
@@ -36,12 +35,10 @@ fn atomic_write_arg_count() {
             next_block: Some(BbName(Name::from_internal(1)))
         }
     );
-
     let b1 = block!(exit());
 
     let f = function(Ret::No, 0, &[], &[b0, b1]);
     let p = program(&[f]);
-
     assert_ub(p, "invalid number of arguments for `Intrinsic::AtomicWrite`")
 }
 
@@ -55,12 +52,10 @@ fn atomic_write_arg_type1() {
             next_block: Some(BbName(Name::from_internal(1)))
         }
     );
-
     let b1 = block!(exit());
 
     let f = function(Ret::No, 0, &[], &[b0, b1]);
     let p = program(&[f]);
-
     assert_ub(p, "invalid first argument to `Intrinsic::AtomicWrite`")
 }
 
@@ -69,7 +64,6 @@ fn atomic_write_arg_type_pow() {
     let locals = [<[u8; 3]>::get_ptype()];
 
     let ptr_ty = raw_ptr_ty( <[u8; 3]>::get_layout() );
-
     let arr = const_array(&[
         const_int::<u8>(0),
         const_int::<u8>(1),
@@ -78,7 +72,6 @@ fn atomic_write_arg_type_pow() {
 
     let b0 = block!(
         storage_live(0),
-
         Terminator::CallIntrinsic {
             intrinsic: Intrinsic::AtomicWrite,
             arguments: list!(addr_of(local(0), ptr_ty), arr),
@@ -86,12 +79,10 @@ fn atomic_write_arg_type_pow() {
             next_block: Some(BbName(Name::from_internal(1)))
         }
     );
-
     let b1 = block!(exit());
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-
     assert_ub(p, "invalid second argument to `Intrinsic::AtomicWrite`, size not power of two")
 }
 
@@ -101,7 +92,6 @@ fn atomic_write_arg_type_size() {
     let locals = [<[u64; 2]>::get_ptype()];
 
     let ptr_ty = raw_ptr_ty( <[u64; 2]>::get_layout() );
-
     let arr = const_array(&[
         const_int::<u64>(0),
         const_int::<u64>(1),
@@ -109,7 +99,6 @@ fn atomic_write_arg_type_size() {
 
     let b0 = block!(
         storage_live(0),
-
         Terminator::CallIntrinsic {
             intrinsic: Intrinsic::AtomicWrite,
             arguments: list!(addr_of(local(0), ptr_ty), arr),
@@ -117,12 +106,10 @@ fn atomic_write_arg_type_size() {
             next_block: Some(BbName(Name::from_internal(1)))
         }
     );
-
     let b1 = block!(exit());
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-
     assert_ub(p, "invalid second argument to `Intrinsic::AtomicWrite`, size too big")
 }
 
@@ -142,12 +129,10 @@ fn atomic_write_ret_type() {
             next_block: Some(BbName(Name::from_internal(1)))
         }
     );
-
     let b1 = block!(exit());
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-
     assert_ub(p, "invalid return type for `Intrinsic::AtomicWrite`")
 }
 
@@ -158,7 +143,6 @@ fn atomic_read_success() {
     let ptr_ty = raw_ptr_ty( <u32>::get_layout() );
 
     // We show that atomic read actually reads by reading 1 from local(1).
-
     let b0 = block!(
         storage_live(0),
         storage_live(1),
@@ -174,7 +158,6 @@ fn atomic_read_success() {
 
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2, b3]);
     let p = program(&[f]);
-
     assert_stop(p);
 }
 
@@ -191,12 +174,10 @@ fn atomic_read_arg_count() {
             next_block: Some(BbName(Name::from_internal(1)))
         }
     );
-
     let b1 = block!(exit());
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-
     assert_ub(p, "invalid number of arguments for `Intrinsic::AtomicRead`")
 }
 
@@ -213,12 +194,10 @@ fn atomic_read_arg_type() {
             next_block: Some(BbName(Name::from_internal(1)))
         }
     );
-
     let b1 = block!(exit());
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-
     assert_ub(p, "invalid first argument to `Intrinsic::AtomicRead`")
 }
 
@@ -232,12 +211,10 @@ fn atomic_read_ret_type_pow() {
         storage_live(0),
         atomic_read(local(0), addr_of(local(0), ptr_ty), 1)
     );
-
     let b1 = block!(exit());
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-
     assert_ub(p, "invalid return type for `Intrinsic::AtomicRead`, size not power of two")
 }
 
@@ -252,11 +229,9 @@ fn atomic_read_ret_type_size() {
         storage_live(0),
         atomic_read(local(0), addr_of(local(0), ptr_ty), 1)
     );
-
     let b1 = block!(exit());
 
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
-
     assert_ub(p, "invalid return type for `Intrinsic::AtomicRead`, size too big")
 }

--- a/tooling/minitest/src/ub/atomic.rs
+++ b/tooling/minitest/src/ub/atomic.rs
@@ -123,7 +123,7 @@ fn atomic_write_arg_type_size() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
 
-    assert_ub(p, "invalid second argument to `Intrinsic::AtomicWrite`, size to big")
+    assert_ub(p, "invalid second argument to `Intrinsic::AtomicWrite`, size too big")
 }
 
 #[test]
@@ -258,5 +258,5 @@ fn atomic_read_ret_type_size() {
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
     let p = program(&[f]);
 
-    assert_ub(p, "invalid return type for `Intrinsic::AtomicRead`, size to big")
+    assert_ub(p, "invalid return type for `Intrinsic::AtomicRead`, size too big")
 }

--- a/tooling/minitest/src/ub/atomic.rs
+++ b/tooling/minitest/src/ub/atomic.rs
@@ -1,0 +1,262 @@
+use crate::*;
+
+#[test]
+fn atomic_write_success() {
+    let locals = [<u32>::get_ptype()];
+
+    let ptr_ty = raw_ptr_ty( <u32>::get_layout() );
+
+    // We show that atomic write actually writes by writing 1 to local(0)
+
+    let b0 = block!(
+        storage_live(0),
+        assign(local(0), const_int::<u32>(0)),
+
+        atomic_write(addr_of(local(0), ptr_ty), const_int::<u32>(1), 1)
+    );
+    let b1 = block!(
+        if_(eq(load(local(0)), const_int::<u32>(1)), 2, 3)
+    );
+    let b2 = block!(exit());
+    let b3 = block!(unreachable());
+
+    let f = function(Ret::No, 0, &locals, &[b0, b1, b2, b3]);
+    let p = program(&[f]);
+
+    assert_stop(p);
+}
+
+#[test]
+fn atomic_write_arg_count() {
+    let b0 = block!(
+        Terminator::CallIntrinsic { 
+            intrinsic: Intrinsic::AtomicWrite, 
+            arguments: list!(), 
+            ret: None, 
+            next_block: Some(BbName(Name::from_internal(1)))
+        }
+    );
+
+    let b1 = block!(exit());
+
+    let f = function(Ret::No, 0, &[], &[b0, b1]);
+    let p = program(&[f]);
+
+    assert_ub(p, "invalid number of arguments for `Intrinsic::AtomicWrite`")
+}
+
+#[test]
+fn atomic_write_arg_type1() {
+    let b0 = block!(
+        Terminator::CallIntrinsic { 
+            intrinsic: Intrinsic::AtomicWrite, 
+            arguments: list!(const_int::<u32>(0), const_int::<u32>(0)), 
+            ret: None, 
+            next_block: Some(BbName(Name::from_internal(1)))
+        }
+    );
+
+    let b1 = block!(exit());
+
+    let f = function(Ret::No, 0, &[], &[b0, b1]);
+    let p = program(&[f]);
+
+    assert_ub(p, "invalid first argument to `Intrinsic::AtomicWrite`")
+}
+
+#[test]
+fn atomic_write_arg_type_pow() {
+    let locals = [<[u8; 3]>::get_ptype()];
+
+    let ptr_ty = raw_ptr_ty( <[u8; 3]>::get_layout() );
+
+    let arr = const_array(&[
+        const_int::<u8>(0),
+        const_int::<u8>(1),
+        const_int::<u8>(69),
+    ], <u8>::get_type());
+
+    let b0 = block!(
+        storage_live(0),
+
+        Terminator::CallIntrinsic { 
+            intrinsic: Intrinsic::AtomicWrite, 
+            arguments: list!(addr_of(local(0), ptr_ty), arr), 
+            ret: None, 
+            next_block: Some(BbName(Name::from_internal(1)))
+        }
+    );
+
+    let b1 = block!(exit());
+
+    let f = function(Ret::No, 0, &locals, &[b0, b1]);
+    let p = program(&[f]);
+
+    assert_ub(p, "invalid second argument to `Intrinsic::AtomicWrite`, size not power of two")
+}
+
+// This test assumes that we test on a memory with `MAX_ATOMIC_SIZE <= 8 byte`.
+#[test]
+fn atomic_write_arg_type_size() {
+    let locals = [<[u64; 2]>::get_ptype()];
+
+    let ptr_ty = raw_ptr_ty( <[u64; 2]>::get_layout() );
+
+    let arr = const_array(&[
+        const_int::<u64>(0),
+        const_int::<u64>(1),
+    ], <u64>::get_type());
+
+    let b0 = block!(
+        storage_live(0),
+
+        Terminator::CallIntrinsic { 
+            intrinsic: Intrinsic::AtomicWrite, 
+            arguments: list!(addr_of(local(0), ptr_ty), arr), 
+            ret: None, 
+            next_block: Some(BbName(Name::from_internal(1)))
+        }
+    );
+
+    let b1 = block!(exit());
+
+    let f = function(Ret::No, 0, &locals, &[b0, b1]);
+    let p = program(&[f]);
+
+    assert_ub(p, "invalid second argument to `Intrinsic::AtomicWrite`, size to big")
+}
+
+#[test]
+fn atomic_write_ret_type() {
+    let locals = [<u64>::get_ptype()];
+
+    let ptr_ty = raw_ptr_ty( <u64>::get_layout() );
+
+    let b0 = block!(
+        storage_live(0),
+
+        Terminator::CallIntrinsic { 
+            intrinsic: Intrinsic::AtomicWrite, 
+            arguments: list!(addr_of(local(0), ptr_ty), const_int::<u64>(0)), 
+            ret: Some(local(0)), 
+            next_block: Some(BbName(Name::from_internal(1)))
+        }
+    );
+
+    let b1 = block!(exit());
+
+    let f = function(Ret::No, 0, &locals, &[b0, b1]);
+    let p = program(&[f]);
+
+    assert_ub(p, "invalid return type for `Intrinsic::AtomicWrite`")
+}
+
+#[test]
+fn atomic_read_success() {
+    let locals = [<u32>::get_ptype(); 2];
+
+    let ptr_ty = raw_ptr_ty( <u32>::get_layout() );
+
+    // We show that atomic read actually reads by reading 1 from local(1).
+
+    let b0 = block!(
+        storage_live(0),
+        storage_live(1),
+        assign(local(1), const_int::<u32>(1)),
+
+        atomic_read(local(0), addr_of(local(1), ptr_ty), 1)
+    );
+    let b1 = block!(
+        if_(eq(load(local(0)), const_int::<u32>(1)), 2, 3)
+    );
+    let b2 = block!(exit());
+    let b3 = block!(unreachable());
+
+    let f = function(Ret::No, 0, &locals, &[b0, b1, b2, b3]);
+    let p = program(&[f]);
+
+    assert_stop(p);
+}
+
+#[test]
+fn atomic_read_arg_count() {
+    let locals = [ <u32>::get_ptype() ];
+
+    let b0 = block!(
+        storage_live(0),
+        Terminator::CallIntrinsic { 
+            intrinsic: Intrinsic::AtomicRead, 
+            arguments: list!(), 
+            ret: Some(local(0)), 
+            next_block: Some(BbName(Name::from_internal(1)))
+        }
+    );
+
+    let b1 = block!(exit());
+
+    let f = function(Ret::No, 0, &locals, &[b0, b1]);
+    let p = program(&[f]);
+
+    assert_ub(p, "invalid number of arguments for `Intrinsic::AtomicRead`")
+}
+
+#[test]
+fn atomic_read_arg_type() {
+    let locals = [ <u32>::get_ptype() ];
+
+    let b0 = block!(
+        storage_live(0),
+        Terminator::CallIntrinsic { 
+            intrinsic: Intrinsic::AtomicRead, 
+            arguments: list!(const_unit()), 
+            ret: Some(local(0)), 
+            next_block: Some(BbName(Name::from_internal(1)))
+        }
+    );
+
+    let b1 = block!(exit());
+
+    let f = function(Ret::No, 0, &locals, &[b0, b1]);
+    let p = program(&[f]);
+
+    assert_ub(p, "invalid first argument to `Intrinsic::AtomicRead`")
+}
+
+#[test]
+fn atomic_read_ret_type_pow() {
+    let locals = [ <()>::get_ptype() ];
+
+    let ptr_ty = raw_ptr_ty( <()>::get_layout() );
+
+    let b0 = block!(
+        storage_live(0),
+        atomic_read(local(0), addr_of(local(0), ptr_ty), 1)
+    );
+
+    let b1 = block!(exit());
+
+    let f = function(Ret::No, 0, &locals, &[b0, b1]);
+    let p = program(&[f]);
+
+    assert_ub(p, "invalid return type for `Intrinsic::AtomicRead`, size not power of two")
+}
+
+// This test assumes that we test on a memory with `MAX_ATOMIC_SIZE <= 8 byte`.
+#[test]
+fn atomic_read_ret_type_size() {
+    let locals = [ <[u64; 2]>::get_ptype() ];
+
+    let ptr_ty = raw_ptr_ty( <[u64; 2]>::get_layout() );
+
+    let b0 = block!(
+        storage_live(0),
+        atomic_read(local(0), addr_of(local(0), ptr_ty), 1)
+    );
+
+    let b1 = block!(exit());
+
+    let f = function(Ret::No, 0, &locals, &[b0, b1]);
+    let p = program(&[f]);
+
+    assert_ub(p, "invalid return type for `Intrinsic::AtomicRead`, size to big")
+}

--- a/tooling/minitest/src/ub/mod.rs
+++ b/tooling/minitest/src/ub/mod.rs
@@ -20,3 +20,4 @@ mod impossible_align;
 mod spawn;
 mod join;
 mod locks;
+mod atomic;

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -116,6 +116,38 @@ pub fn div<T: TypeConv>(l: ValueExpr, r: ValueExpr) -> ValueExpr {
     int_binop::<T>(BinOpInt::Div, l, r)
 }
 
+fn int_rel(op: IntRel, l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    ValueExpr::BinOp {
+        operator: BinOp::IntRel(op),
+        left: GcCow::new(l),
+        right: GcCow::new(r),
+    }
+}
+
+pub fn eq(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_rel(IntRel::Eq, l, r)
+}
+
+pub fn ne(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_rel(IntRel::Ne, l, r)
+}
+
+pub fn ge(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_rel(IntRel::Ge, l, r)
+}
+
+pub fn gt(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_rel(IntRel::Gt, l, r)
+}
+
+pub fn le(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_rel(IntRel::Le, l, r)
+}
+
+pub fn lt(l: ValueExpr, r: ValueExpr) -> ValueExpr {
+    int_rel(IntRel::Lt, l, r)
+}
+
 pub enum InBounds {
     Yes,
     No,

--- a/tooling/miniutil/src/build/statement.rs
+++ b/tooling/miniutil/src/build/statement.rs
@@ -111,6 +111,24 @@ pub fn join(thread_id: ValueExpr, next: u32) -> Terminator {
     }
 }
 
+pub fn atomic_write(ptr: ValueExpr, src: ValueExpr, next: u32) -> Terminator {
+    Terminator::CallIntrinsic { 
+        intrinsic: Intrinsic::AtomicWrite, 
+        arguments: list!(ptr, src), 
+        ret: None, 
+        next_block: Some(BbName(Name::from_internal(next))) 
+    }
+}
+
+pub fn atomic_read(dest: PlaceExpr, ptr: ValueExpr, next: u32) -> Terminator {
+    Terminator::CallIntrinsic { 
+        intrinsic: Intrinsic::AtomicRead, 
+        arguments: list!(ptr), 
+        ret: Some(dest), 
+        next_block: Some(BbName(Name::from_internal(next))) 
+    }
+}
+
 pub fn create_lock(ret: PlaceExpr, next: u32) -> Terminator {
     Terminator::CallIntrinsic { 
         intrinsic: Intrinsic::Lock(LockIntrinsic::Create), 

--- a/tooling/miniutil/src/build/statement.rs
+++ b/tooling/miniutil/src/build/statement.rs
@@ -112,20 +112,20 @@ pub fn join(thread_id: ValueExpr, next: u32) -> Terminator {
 }
 
 pub fn atomic_write(ptr: ValueExpr, src: ValueExpr, next: u32) -> Terminator {
-    Terminator::CallIntrinsic { 
-        intrinsic: Intrinsic::AtomicWrite, 
-        arguments: list!(ptr, src), 
-        ret: None, 
-        next_block: Some(BbName(Name::from_internal(next))) 
+    Terminator::CallIntrinsic {
+        intrinsic: Intrinsic::AtomicWrite,
+        arguments: list!(ptr, src),
+        ret: None,
+        next_block: Some(BbName(Name::from_internal(next)))
     }
 }
 
 pub fn atomic_read(dest: PlaceExpr, ptr: ValueExpr, next: u32) -> Terminator {
-    Terminator::CallIntrinsic { 
-        intrinsic: Intrinsic::AtomicRead, 
-        arguments: list!(ptr), 
-        ret: Some(dest), 
-        next_block: Some(BbName(Name::from_internal(next))) 
+    Terminator::CallIntrinsic {
+        intrinsic: Intrinsic::AtomicRead,
+        arguments: list!(ptr),
+        ret: Some(dest),
+        next_block: Some(BbName(Name::from_internal(next)))
     }
 }
 

--- a/tooling/miniutil/src/fmt/function.rs
+++ b/tooling/miniutil/src/fmt/function.rs
@@ -209,6 +209,8 @@ fn fmt_terminator(t: Terminator, comptypes: &mut Vec<CompType>) -> String {
                 Intrinsic::Deallocate => "deallocate",
                 Intrinsic::Spawn => "spawn",
                 Intrinsic::Join => "join",
+                Intrinsic::AtomicWrite => "atomic_write",
+                Intrinsic::AtomicRead => "atomic_read",
                 Intrinsic::Lock(LockIntrinsic::Acquire) => "lock-acquire",
                 Intrinsic::Lock(LockIntrinsic::Create) => "lock-create",
                 Intrinsic::Lock(LockIntrinsic::Release) => "lock-release",


### PR DESCRIPTION
Add `AtomicMemory` a wrapper for for `Memory`. This allows us to have intrinsics for atomics. We can later use this wrapper to create a data race detection.