### PR TITLE
Data race

### DIFF
--- a/spec/lang/locks.md
+++ b/spec/lang/locks.md
@@ -29,7 +29,7 @@ impl<M: Memory> ThreadManager<M> {
     }
 
     pub fn lock_acquire(&mut self, lock_id: LockId) -> Result {
-        let active = self.active_thread.unwrap();
+        let active = self.active_thread;
 
         let Some(lock) = self.locks.get(lock_id) else {
             throw_ub!("acquiring non-existing lock");
@@ -54,7 +54,7 @@ impl<M: Memory> ThreadManager<M> {
     }
 
     pub fn lock_release(&mut self, lock_id: LockId) -> NdResult {
-        let active = self.active_thread.unwrap();
+        let active = self.active_thread;
 
         let Some(lock) = self.locks.get(lock_id) else {
             throw_ub!("releasing non-existing lock");

--- a/spec/lang/machine.md
+++ b/spec/lang/machine.md
@@ -88,7 +88,7 @@ pub enum ThreadState {
 }
 
 /// The ID of a thread is an index into the ThreadManager's `threads` list.
-type ThreadId = Int;
+pub type ThreadId = Int;
 
 /// The thread manager tracks the list of all threads, and the thread that is currently taking a step.
 /// The latter is only needed during a step of execution;

--- a/spec/lang/step.md
+++ b/spec/lang/step.md
@@ -34,7 +34,7 @@ impl<M: Memory> Machine<M> {
             thread.state == ThreadState::Enabled
         })?;
 
-        self.thread_manager.active_thread = Some(thread_id);
+        self.thread_manager.active_thread = thread_id;
 
         // Prepare data race detection for next step.
         self.mem.next_step(self.thread_manager.active_thread);

--- a/spec/lang/step.md
+++ b/spec/lang/step.md
@@ -34,6 +34,7 @@ impl<M: Memory> Machine<M> {
             thread.state == ThreadState::Enabled
         })?;
 
+        // Update current thread; remember previous thread for data race detection.
         let prev_thread = self.thread_manager.active_thread;
         self.thread_manager.active_thread = thread_id;
 

--- a/spec/lang/step.md
+++ b/spec/lang/step.md
@@ -36,6 +36,9 @@ impl<M: Memory> Machine<M> {
 
         self.thread_manager.active_thread = Some(thread_id);
 
+        // Prepare data race detection for next step.
+        self.mem.next_step(self.thread_manager.active_thread);
+
         let frame = self.cur_frame();
         let block = &frame.func.blocks[frame.next_block];
         if frame.next_stmt == block.statements.len() {

--- a/spec/mem/atomic.md
+++ b/spec/mem/atomic.md
@@ -8,12 +8,12 @@ pub struct AtomicMemory<M: Memory> {
     memory: M,
 
     /// The Id of the current thread
-    current_thread: Option<ThreadId>,
+    current_thread: ThreadId,
     /// List of all memory access done by the active thread in the current step.
     current_accesses: List<Access>,
 
     /// The Id of the last thread
-    last_thread: Option<ThreadId>,
+    last_thread: ThreadId,
     /// List of all memory accesses done by the last thread in the last step.
     last_accesses: List<Access>,
 }
@@ -52,9 +52,9 @@ impl<M: Memory> AtomicMemory<M> {
     pub fn new() -> Self {
         Self { 
             memory: M::new(),
-            current_thread: None,
+            current_thread: ThreadId::ZERO,
             current_accesses: list![],
-            last_thread: None,
+            last_thread: ThreadId::ZERO,
             last_accesses: list![],
         }
     }
@@ -117,7 +117,7 @@ impl<M: Memory> AtomicMemory<M> {
     fn track_access(&mut self, access: Access) -> Result {
         self.current_accesses.push(access);
 
-        if self.current_thread == self.last_thread || self.last_thread == None { return Ok(()) }
+        if self.current_thread == self.last_thread { return Ok(()) }
 
         if self.last_accesses.any(|other| access.races(&other)) {
             throw_ub!("Data races");
@@ -127,7 +127,7 @@ impl<M: Memory> AtomicMemory<M> {
     }
 
     /// Take meassures to track the next execution step.
-    pub fn next_step(&mut self, thread: Option<ThreadId>) {
+    pub fn next_step(&mut self, thread: ThreadId) {
         self.last_thread = self.current_thread;
         self.last_accesses = self.current_accesses;
 

--- a/spec/mem/atomic.md
+++ b/spec/mem/atomic.md
@@ -6,6 +6,16 @@ For now atomicity is ignored; this will change in the future.
 ```rust
 pub struct AtomicMemory<M: Memory> {
     memory: M,
+
+    /// The Id of the current thread
+    current_thread: Option<ThreadId>,
+    /// List of all memory access done by the active thread in the current step.
+    current_accesses: List<Access>,
+
+    /// The Id of the last thread
+    last_thread: Option<ThreadId>,
+    /// List of all memory accesses done by the last thread in the last step.
+    last_accesses: List<Access>,
 }
 
 /// The different kinds of atomicity.
@@ -17,9 +27,36 @@ pub enum Atomicity {
     None,
 }
 
+/// Internal type used to track the type of a memory access.
+enum AccessType {
+    Store,
+    Load,
+}
+
+/// Access contains all information the data race detection needs about a single access.
+struct Access {
+    ty: AccessType,
+    atomicity: Atomicity,
+    addr: Address,
+    len: Int,
+}
+```
+
+## Interface
+
+The atomic memory presents a very similar interface to the `Memory`.
+It differs in both store and load where we also take the `Atomicity` of an operation.
+
+```rust
 impl<M: Memory> AtomicMemory<M> {
     pub fn new() -> Self {
-        Self { memory: M::new() }
+        Self { 
+            memory: M::new(),
+            current_thread: None,
+            current_accesses: list![],
+            last_thread: None,
+            last_accesses: list![],
+        }
     }
 
     /// Create a new allocation.
@@ -33,13 +70,19 @@ impl<M: Memory> AtomicMemory<M> {
         self.memory.deallocate(ptr, size, align)
     }
 
-    /// Write some bytes to memory.
-    pub fn store(&mut self, _atomicity: Atomicity, ptr: Pointer<M::Provenance>, bytes: List<AbstractByte<M::Provenance>>, align: Align) -> Result {
+    /// Write some bytes to memory and check for data races.
+    pub fn store(&mut self, atomicity: Atomicity, ptr: Pointer<M::Provenance>, bytes: List<AbstractByte<M::Provenance>>, align: Align) -> Result {
+        let access = Access::new(AccessType::Store, atomicity, ptr.addr, bytes.len());
+        self.track_access(access)?;
+
         self.memory.store(ptr, bytes, align)
     }
 
-    /// Read some bytes from memory.
-    pub fn load(&mut self, _atomicity: Atomicity, ptr: Pointer<M::Provenance>, len: Size, align: Align) -> Result<List<AbstractByte<M::Provenance>>> {
+    /// Read some bytes from memory and check for data races.
+    pub fn load(&mut self, atomicity: Atomicity, ptr: Pointer<M::Provenance>, len: Size, align: Align) -> Result<List<AbstractByte<M::Provenance>>> {
+        let access = Access::new(AccessType::Load, atomicity, ptr.addr, len.bytes());
+        self.track_access(access)?;
+
         self.memory.load(ptr, len, align)
     }
 
@@ -59,6 +102,69 @@ impl<M: Memory> AtomicMemory<M> {
     /// Checks that `size` is not too large for the Memory.
     pub fn valid_size(size: Size) -> bool {
         M::valid_size(size)
+    }
+}
+```
+
+## Data race detection
+
+Here we define the operations needed to make data race detection.
+
+```rust
+impl<M: Memory> AtomicMemory<M> {
+    /// Checks if this access is in a data race with any access that happend in the last access.
+    /// It keeps track of the access for the next step.
+    fn track_access(&mut self, access: Access) -> Result {
+        self.current_accesses.push(access);
+
+        if self.current_thread == self.last_thread || self.last_thread == None { return Ok(()) }
+
+        if self.last_accesses.any(|other| access.races(&other)) {
+            throw_ub!("Data races");
+        }
+
+        Ok(())
+    }
+
+    /// Take meassures to track the next execution step.
+    pub fn next_step(&mut self, thread: Option<ThreadId>) {
+        self.last_thread = self.current_thread;
+        self.last_accesses = self.current_accesses;
+
+        self.current_thread = thread;
+        self.current_accesses = list![];
+    }
+}
+
+impl Access {
+    /// Indicates if a races happend between the two given accesses.
+    /// We assume they happen on different threads.
+    fn races(&self, other: &Self) -> bool {
+        // At least one access modifies the data.
+        if self.ty == AccessType::Load && other.ty == AccessType::Load { return false; }
+
+        // At least one access is non atomic
+        if self.atomicity == Atomicity::Atomic && other.atomicity == Atomicity::Atomic { return false; }
+
+        // The accesses overlap.
+        let end_addr = self.addr + self.len;
+        let other_end_addr = other.addr + other.len;
+        end_addr > other.addr && other_end_addr > self.addr
+    }
+}
+```
+
+## Utility
+
+```rust
+impl Access {
+    fn new(ty: AccessType, atomicity: Atomicity, addr: Address, len: Int) -> Self {
+        Access {
+            ty,
+            atomicity,
+            addr,
+            len,
+        }
     }
 }
 ```

--- a/spec/mem/atomic.md
+++ b/spec/mem/atomic.md
@@ -125,7 +125,8 @@ impl<M: Memory> AtomicMemory<M> {
         Ok(())
     }
 
-    /// Prepare memory to track accesses of next step.
+    /// Prepare memory to track accesses of next step: reset the internal access list to
+    /// be empty, and return the list of previously collected accesses.
     pub fn reset_accesses(&mut self) -> List<Access> {
         let prev_accesses = self.current_accesses;
         self.current_accesses = list![];

--- a/spec/mem/atomic.md
+++ b/spec/mem/atomic.md
@@ -50,7 +50,7 @@ It differs in both store and load where we also take the `Atomicity` of an opera
 ```rust
 impl<M: Memory> AtomicMemory<M> {
     pub fn new() -> Self {
-        Self { 
+        Self {
             memory: M::new(),
             current_thread: ThreadId::ZERO,
             current_accesses: list![],
@@ -120,7 +120,7 @@ impl<M: Memory> AtomicMemory<M> {
         if self.current_thread == self.last_thread { return Ok(()) }
 
         if self.last_accesses.any(|other| access.races(&other)) {
-            throw_ub!("Data races");
+            throw_ub!("Data race");
         }
 
         Ok(())

--- a/spec/mem/prelude.md
+++ b/spec/mem/prelude.md
@@ -4,5 +4,5 @@ For the files in this folder, we assume some definitions and parameters to alway
 
 ```rust
 use crate::prelude::*;
-use lang::PtrType;
+use lang::{ PtrType, ThreadId };
 ```

--- a/tooling/minitest/src/lib.rs
+++ b/tooling/minitest/src/lib.rs
@@ -31,3 +31,25 @@ pub fn assert_ub(prog: Program, msg: &str) {
 pub fn assert_ill_formed(prog: Program) {
     assert_eq!(run_program(prog), TerminationInfo::IllFormed);
 }
+
+
+/// Run the program multiple times. Checks if we get a data race in some execution
+/// This automatically fails if the program does not terminate correctly if the data race did not occur.
+pub fn has_data_race(prog: Program) -> bool {
+    let data_race_string = minirust_rs::prelude::String::from_internal("Data race".to_string());
+
+    for _ in 0..20 {
+        match run_program(prog) {
+            TerminationInfo::MachineStop => {},
+            TerminationInfo::Ub(ub) => {
+                if ub == data_race_string {
+                    return true;
+                }
+                panic!("Non data race undefined behavior");
+            },
+            termination_info => panic!("{:?}", termination_info)
+        }
+    }
+
+    false
+}

--- a/tooling/minitest/src/ub/data_race.rs
+++ b/tooling/minitest/src/ub/data_race.rs
@@ -60,6 +60,8 @@ fn racy_program(main_access: AccessPattern, s_access: AccessPattern) -> Program 
     let s_fun = function(Ret::No, 0, &[], &[s_b0, s_b1]);
 
     // global(0) is needed for the race behavior; the others are used to support our operations.
+    // We use globals instead of locals because locals would need an additional instruction (`storage_live`)
+    // before the race condition which would decrease the chance of it being caught.
     let globals = [global_int::<u32>(); 3];
 
     program_with_globals(&[main, s_fun], &globals)

--- a/tooling/minitest/src/ub/data_race.rs
+++ b/tooling/minitest/src/ub/data_race.rs
@@ -1,0 +1,166 @@
+use crate::*;
+
+enum AccessType {
+    Load,
+    Store,
+}
+
+struct AccessPattern(AccessType, Atomicity);
+
+// A block that does the access pattern on global(0) using the support global
+fn access_block(access: AccessPattern, support_global: u32, next: u32) -> BasicBlock {
+    let ptr_ty = raw_ptr_ty( <u32>::get_layout() );
+    let addr = addr_of(global::<u32>(0), ptr_ty);
+    match access {
+        AccessPattern(AccessType::Load, Atomicity::Atomic) => {
+            block!(
+                atomic_read(global::<u32>(support_global), addr, next)
+            )
+        },
+        AccessPattern(AccessType::Load, Atomicity::None) => {
+            block!(
+                assign(global::<u32>(support_global), load(global::<u32>(0))),
+                goto(next),
+            )
+        },
+        AccessPattern(AccessType::Store, Atomicity::Atomic) => {
+            block!(
+                atomic_write(addr, load(global::<u32>(support_global)), next)
+            )
+        },
+        AccessPattern(AccessType::Store, Atomicity::None) => {
+            block!(
+                assign(global::<u32>(0), load(global::<u32>(support_global))),
+                goto(next),
+            )
+        }
+    }
+}
+
+fn racy_program(main_access: AccessPattern, s_access: AccessPattern) -> Program {
+    // The main thread.
+    let main_locals = [<u32>::get_ptype()];
+
+    let main_b0 = block!(
+        storage_live(0),
+        spawn(fn_ptr(1), Some(local(0)), 1),
+    );
+    let main_b1 = access_block(main_access, 1, 2);
+    let main_b2 = block!(
+        join(load(local(0)), 3),
+    );
+    let main_b3 = block!( exit() );
+    let main = function(Ret::No, 0, &main_locals, &[main_b0, main_b1, main_b2, main_b3]);
+
+    // The second thread.
+    let s_b0 = access_block(s_access, 2, 1);
+    let s_b1 = block!(
+        return_()
+    );
+    let s_fun = function(Ret::No, 0, &[], &[s_b0, s_b1]);
+
+    // global(0) is needed for the race behavior the others are used to support our operations.
+    let globals = [global_int::<u32>(); 3];
+
+    program_with_globals(&[main, s_fun], &globals)
+}
+
+#[test]
+fn atomic_load_atomic_load() {
+    let p = racy_program(
+        AccessPattern(AccessType::Load, Atomicity::Atomic),
+        AccessPattern(AccessType::Load, Atomicity::Atomic)
+    );
+
+    assert!(!has_data_race(p))
+}
+
+#[test]
+fn atomic_load_atomic_store() {
+    let p = racy_program(
+        AccessPattern(AccessType::Load, Atomicity::Atomic),
+        AccessPattern(AccessType::Store, Atomicity::Atomic)
+    );
+
+    assert!(!has_data_race(p))
+}
+
+#[test]
+fn atomic_load_non_atomic_load() {
+    let p = racy_program(
+        AccessPattern(AccessType::Load, Atomicity::Atomic),
+        AccessPattern(AccessType::Load, Atomicity::None)
+    );
+
+    assert!(!has_data_race(p))
+}
+
+#[test]
+fn atomic_load_non_atomic_store() {
+    let p = racy_program(
+        AccessPattern(AccessType::Load, Atomicity::Atomic),
+        AccessPattern(AccessType::Store, Atomicity::None)
+    );
+
+    assert!(has_data_race(p))
+}
+
+#[test]
+fn atomic_store_atomic_store() {
+    let p = racy_program(
+        AccessPattern(AccessType::Store, Atomicity::Atomic),
+        AccessPattern(AccessType::Store, Atomicity::Atomic)
+    );
+
+    assert!(!has_data_race(p))
+}
+
+#[test]
+fn atomic_store_non_atomic_load() {
+    let p = racy_program(
+        AccessPattern(AccessType::Store, Atomicity::Atomic),
+        AccessPattern(AccessType::Load, Atomicity::None)
+    );
+
+    assert!(has_data_race(p))
+}
+
+#[test]
+fn atomic_store_non_atomic_store() {
+    let p = racy_program(
+        AccessPattern(AccessType::Store, Atomicity::Atomic),
+        AccessPattern(AccessType::Store, Atomicity::None)
+    );
+
+    assert!(has_data_race(p))
+}
+
+#[test]
+fn non_atomic_load_non_atomic_load() {
+    let p = racy_program(
+        AccessPattern(AccessType::Load, Atomicity::None),
+        AccessPattern(AccessType::Load, Atomicity::None)
+    );
+
+    assert!(!has_data_race(p))
+}
+
+#[test]
+fn non_atomic_load_non_atomic_store() {
+    let p = racy_program(
+        AccessPattern(AccessType::Load, Atomicity::None),
+        AccessPattern(AccessType::Store, Atomicity::None)
+    );
+
+    assert!(has_data_race(p))
+}
+
+#[test]
+fn non_atomic_store_non_atomic_store() {
+    let p = racy_program(
+        AccessPattern(AccessType::Store, Atomicity::None),
+        AccessPattern(AccessType::Store, Atomicity::None)
+    );
+
+    assert!(has_data_race(p))
+}

--- a/tooling/minitest/src/ub/data_race.rs
+++ b/tooling/minitest/src/ub/data_race.rs
@@ -7,7 +7,8 @@ enum AccessType {
 
 struct AccessPattern(AccessType, Atomicity);
 
-// A block that does the access pattern on global(0) using the support global
+// A block that does the access pattern on global(0): stores put the value of the "support global"
+// into global(0); loads pit the value of global(0) into the "support global".
 fn access_block(access: AccessPattern, support_global: u32, next: u32) -> BasicBlock {
     let ptr_ty = raw_ptr_ty( <u32>::get_layout() );
     let addr = addr_of(global::<u32>(0), ptr_ty);

--- a/tooling/minitest/src/ub/data_race.rs
+++ b/tooling/minitest/src/ub/data_race.rs
@@ -59,7 +59,7 @@ fn racy_program(main_access: AccessPattern, s_access: AccessPattern) -> Program 
     );
     let s_fun = function(Ret::No, 0, &[], &[s_b0, s_b1]);
 
-    // global(0) is needed for the race behavior the others are used to support our operations.
+    // global(0) is needed for the race behavior; the others are used to support our operations.
     let globals = [global_int::<u32>(); 3];
 
     program_with_globals(&[main, s_fun], &globals)

--- a/tooling/minitest/src/ub/mod.rs
+++ b/tooling/minitest/src/ub/mod.rs
@@ -22,3 +22,4 @@ mod join;
 mod locks;
 mod atomic;
 mod compare_exchange;
+mod data_race;

--- a/tooling/miniutil/src/run.rs
+++ b/tooling/miniutil/src/run.rs
@@ -2,8 +2,6 @@ use crate::{*, mock_write::MockWrite};
 
 /// Run the program and return its TerminationInfo.
 /// Stdout/stderr are just forwarded to the host.
-///
-/// We fix `BasicMemory` as a memory for now.
 pub fn run_program(prog: Program) -> TerminationInfo {
     let out = std::io::stdout();
     let err = std::io::stderr();
@@ -17,8 +15,6 @@ pub fn run_program(prog: Program) -> TerminationInfo {
 
 /// Run the program and return stdout as a `Vec<String>`  or a termination info
 /// if it did not terminate correctly. Stderr is just forwarded to the host.
-///
-/// We fix `BasicMemory` as a memory for now.
 pub fn get_stdout(prog: Program) -> Result<Vec<String>, TerminationInfo> {
     let out = MockWrite::new();
     let err = std::io::stderr();
@@ -32,6 +28,8 @@ pub fn get_stdout(prog: Program) -> Result<Vec<String>, TerminationInfo> {
 }
 
 /// Run the program to completion using the given writers for stdout/stderr.
+/// 
+/// We fix `BasicMemory` as a memory for now.
 fn run(prog: Program, stdout: impl GcWrite, stderr: impl GcWrite) -> Result<!, TerminationInfo> {
     let res: NdResult<!> = try {
 


### PR DESCRIPTION
This adds a data race detection system for minirust. It assumes sequential consistency and is very chance dependent since it only catches data races if the racing operations are executed after each other by the interpreter.

I also changed that the active thread is now just a `ThreadId` and not an `Option<ThreadId>`. This implies that memory operations by the machine before it is running are done by the master thread.