### PR TITLE
Deadlock

### DIFF
--- a/spec/lang/step.md
+++ b/spec/lang/step.md
@@ -20,6 +20,10 @@ For statements it also advances the program counter.
 impl<M: Memory> Machine<M> {
     /// To run a MiniRust program, call this in a loop until it throws an `Err` (UB or termination).
     pub fn step(&mut self) -> NdResult {
+        if !self.thread_manager.threads.any( |thread| thread.state == ThreadState::Enabled ) {
+            throw_deadlock!();
+        }
+
         let distr = libspecr::IntDistribution {
             start: Int::ZERO,
             end: Int::from(self.thread_manager.threads.len()),

--- a/spec/prelude/main.md
+++ b/spec/prelude/main.md
@@ -20,6 +20,8 @@ pub enum TerminationInfo {
     MachineStop,
     /// The program was ill-formed.
     IllFormed,
+    /// The program did not terminate but no thread can make progress.
+    Deadlock,
 }
 
 /// Some macros for convenient yeeting, i.e., return an error from a
@@ -42,6 +44,11 @@ macro_rules! throw_machine_stop {
 macro_rules! throw_ill_formed {
     () => {
         do yeet TerminationInfo::IllFormed
+    };
+}
+macro_rules! throw_deadlock {
+    () => {
+        do yeet TerminationInfo::Deadlock
     };
 }
 

--- a/tooling/minitest/src/deadlock/join_lock.rs
+++ b/tooling/minitest/src/deadlock/join_lock.rs
@@ -1,0 +1,34 @@
+use crate::*;
+
+#[test]
+fn deadlock() {
+    // The main function creates a lock and acquires it.
+    // The second function then tries to get this lock while the main tries to join the second thread.
+    // In such a situation both threads wait for each other and we have a deadlock.
+
+    // The locals are used to store the thread ids.
+    let locals = [<u32>::get_ptype()];
+
+    let b0 = block!( create_lock(global::<u32>(0), 1) );
+    let b1 = block!( acquire(load(global::<u32>(0)), 2) );
+    let b2 = block!(
+        storage_live(0),
+        spawn(fn_ptr(1), Some(local(0)), 3)
+    );
+    let b3 = block!( join(load(local(0)), 4) );
+    let b4 = block!( release(load(global::<u32>(0)), 5) );
+    let b5 = block!( exit() );
+    let main = function(Ret::No, 0, &locals, &[b0, b1, b2, b3, b4, b5]);
+
+    let b0 = block!( acquire(load(global::<u32>(0)), 1) );
+    let b1 = block!( release(load(global::<u32>(0)), 2) );
+    let b2 = block!( return_() );
+    let second = function(Ret::No, 0, &[], &[b0,b1,b2]);
+
+    // global(0) is used as a lock. We store the lock id there.
+    let globals = [global_int::<u32>()];
+
+    let p = program_with_globals(&[main, second], &globals);
+
+    assert_deadlock(p);
+}

--- a/tooling/minitest/src/deadlock/mod.rs
+++ b/tooling/minitest/src/deadlock/mod.rs
@@ -1,0 +1,1 @@
+mod join_lock;

--- a/tooling/minitest/src/lib.rs
+++ b/tooling/minitest/src/lib.rs
@@ -19,6 +19,7 @@ pub use std::string::String;
 mod pass;
 mod ub;
 mod ill_formed;
+mod deadlock;
 
 pub fn assert_stop(prog: Program) {
     assert_eq!(run_program(prog), TerminationInfo::MachineStop);
@@ -30,6 +31,10 @@ pub fn assert_ub(prog: Program, msg: &str) {
 
 pub fn assert_ill_formed(prog: Program) {
     assert_eq!(run_program(prog), TerminationInfo::IllFormed);
+}
+
+pub fn assert_deadlock(prog: Program) {
+    assert_eq!(run_program(prog), TerminationInfo::Deadlock);
 }
 
 


### PR DESCRIPTION
So far we had an issue when there was no enabled thread. The non determinism would not work for any value of `active_thread`. This is why we added a new termination info for such a case.

This is not UB because rust considers a deadlock as correct behavior.