### PR TITLE
Refactoring calls and returns

### DIFF
--- a/spec/lang/machine.md
+++ b/spec/lang/machine.md
@@ -48,7 +48,8 @@ struct StackFrame<M: Memory> {
 
     /// `next_block` and `next_stmt` describe the next statement/terminator to execute (the "program counter").
     /// `next_block` identifies the basic block,
-    next_block: BbName,
+    /// next_block is None after calling a function without giving a basic block to return to. UB is raised after the function returns.
+    next_block: Option<BbName>,
 
     /// If `next_stmt` is equal to the number of statements in this block (an
     /// out-of-bounds index in the statement list), it refers to the terminator.
@@ -203,7 +204,7 @@ impl<M: Memory> Machine<M> {
 impl<M: Memory> StackFrame<M> {
     /// jump to the beginning of the given block.
     fn jump_to_block(&mut self, b: BbName) {
-        self.next_block = b;
+        self.next_block = Some(b);
         self.next_stmt = Int::ZERO;
     }
 }
@@ -223,7 +224,7 @@ impl<M: Memory> Thread<M> {
             func,
             locals: Map::new(),
             caller_return_info: None,
-            next_block: func.start,
+            next_block: Some(func.start),
             next_stmt: Int::ZERO,
         };
 

--- a/spec/lang/machine.md
+++ b/spec/lang/machine.md
@@ -57,9 +57,6 @@ struct StackFrame<M: Memory> {
 }
 
 struct CallerReturnInfo<M: Memory> {
-    /// The basic block to jump to when the callee returns.
-    /// If `None`, UB will be raised when the callee returns.
-    next_block: Option<BbName>,
     /// The place where the caller wants to see the return value,
     /// and the type it should be stored at.
     /// If `None`, the return value will be discarded.

--- a/spec/lang/step.md
+++ b/spec/lang/step.md
@@ -526,7 +526,6 @@ impl<M: Memory> Machine<M> {
             func,
             locals,
             caller_return_info: Some(CallerReturnInfo {
-                next_block,
                 ret_place,
             }),
             next_block: Some(func.start),

--- a/tooling/minitest/src/ub/return_.rs
+++ b/tooling/minitest/src/ub/return_.rs
@@ -64,7 +64,7 @@ fn return_no_next() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f, other_f]);
     dump_program(p);
-    assert_ub(p, "return from a function where caller did not specify next block");
+    assert_ub(p, "return from a call where caller did not specify next block");
 }
 
 
@@ -85,6 +85,6 @@ fn return_intrinsic_no_next() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "return from an intrinsic where caller did not specify next block");
+    assert_ub(p, "return from a call where caller did not specify next block");
 }
 


### PR DESCRIPTION
Changes in this PR:

1. the next_block field in StackFrame is now an Option<BbName>, where None means the Call didn't have a next_block
2. that field is updated by the Call in that function, rather than the subsequent return from the callee
3. UB from returning to a caller without a next_block is delayed to the next step, where it is seen that the top frame has next_block == None
4. similarly, thread termination is delayed to when an enabled thread is selected for the next step, but has an empty stack, which also fixes the final return from a thread not deallocating its locals

These changes together mean the return from a function doesn't actually care about its caller's stack frame, which will help with further changes I have planned.

One downside is that this loses the information of which call-statement in the caller got us here, since it's possible for multiple call-statements to have the same next_block, but it could be tracked separately if needed for e.g. diagnostics.