### PR TITLE
Spawn rework

### DIFF
--- a/spec/lang/intrinsic.md
+++ b/spec/lang/intrinsic.md
@@ -185,7 +185,7 @@ impl<M: Memory> Machine<M> {
         arguments: List<(Value<M>, Type)>,
         ret_ty: Type,
     ) -> NdResult<Value<M>> {
-        if arguments.len() != 1 {
+        if arguments.len() != 2 {
             throw_ub!("invalid number of arguments for `Intrinsic::Spawn`");
         }
 
@@ -194,21 +194,28 @@ impl<M: Memory> Machine<M> {
         };
 
         let func = self.fn_from_addr(ptr.addr)?;
-
-        if func.args.len() != 0 {
-            throw_ub!("invalid first argument to `Intrinsic::Spawn`, function takes arguments");
+        if func.args.len() != 1 {
+            throw_ub!("invalid first argument to `Intrinsic::Spawn`, function should take one argument.");
         }
 
-        // This is taken from Miri. It also does not allow for a return value in the root function of a thread.
-        if func.ret.is_some() {
-            throw_ub!("invalid first argument to `Intrinsic::Spawn`, function returns something");
+        let (data_ptr, data_ptr_ty) = arguments[1];
+        if !matches!(data_ptr_ty, Type::Ptr(_)) {
+            throw_ub!("invalid second argument to `Intrinsic::Spawn`, data pointer should be a raw pointer.");
+        }
+
+        // This is taken from Miri. It discards the return value of the function.
+        // We enforce this by only allowing functions that return zero-sized types such as () and !.
+        if let Some(name) = func.ret {
+            if func.locals[name].ty.size::<M::T>() != Size::ZERO {
+                throw_ub!("invalid first argument to `Intrinsic::Spawn`, function returns something non zero sized");
+            }
         }
 
         if !matches!(ret_ty, Type::Int(_)) {
             throw_ub!("invalid return type for `Intrinsic::Spawn`")
         }
 
-        let thread_id = self.spawn(func)?;
+        let thread_id = self.spawn(func, data_ptr, data_ptr_ty)?;
 
         ret(Value::Int(thread_id))
     }

--- a/spec/lang/intrinsic.md
+++ b/spec/lang/intrinsic.md
@@ -192,7 +192,6 @@ impl<M: Memory> Machine<M> {
         let Value::Ptr(ptr) = arguments[0].0 else {
             throw_ub!("invalid first argument to `Intrinsic::Spawn`");
         };
-
         let func = self.fn_from_addr(ptr.addr)?;
         if func.args.len() != 1 {
             throw_ub!("invalid first argument to `Intrinsic::Spawn`, function should take one argument.");
@@ -200,7 +199,7 @@ impl<M: Memory> Machine<M> {
 
         let (data_ptr, data_ptr_ty) = arguments[1];
         if !matches!(data_ptr_ty, Type::Ptr(_)) {
-            throw_ub!("invalid second argument to `Intrinsic::Spawn`, data pointer should be a raw pointer.");
+            throw_ub!("invalid second argument to `Intrinsic::Spawn`, data pointer should be a pointer.");
         }
 
         // This is taken from Miri. It discards the return value of the function.

--- a/spec/lang/locks.md
+++ b/spec/lang/locks.md
@@ -84,6 +84,9 @@ impl<M: Memory> Machine<M> {
                         thread.state = ThreadState::Enabled;
                     });
 
+                    // The acquirer got synchronized because it got enabled by this thread.
+                    self.synchronized_threads.insert(acquirer_id);
+
                     // Rather than unlock and lock again we just change the lock owner.
                     self.locks.mutate_at(lock_id, |lock| {
                         *lock = LockState::LockedBy(acquirer_id);

--- a/spec/lang/machine.md
+++ b/spec/lang/machine.md
@@ -148,7 +148,7 @@ impl<M: Memory> Machine<M> {
             intptrcast: IntPtrCast::new(),
             global_ptrs,
             fn_addrs,
-            threads: list![Thread::new(start_fn)],
+            threads: list![Thread::main(start_fn)],
             locks: List::new(),
             active_thread: ThreadId::ZERO,
             stdout,
@@ -198,7 +198,7 @@ Next, we define how to create a thread.
 
 ```rust
 impl<M: Memory> Thread<M> {
-    fn new(func: Function) -> Self {
+    fn new(func: Function, locals: Map<LocalName, Place<M>>) -> Self {
         // Setup the initial stack frame.
         // For the main thread, well-formedness ensures that the func has
         // no return value and no arguments.
@@ -206,7 +206,7 @@ impl<M: Memory> Thread<M> {
         // that the func has no arguments.
         let init_frame = StackFrame {
             func,
-            locals: Map::new(),
+            locals,
             caller_return_info: None,
             next_block: func.start,
             next_stmt: Int::ZERO,
@@ -216,6 +216,10 @@ impl<M: Memory> Thread<M> {
             state: ThreadState::Enabled,
             stack: list![init_frame],
         }
+    }
+
+    fn main(func: Function) -> Self {
+        Self::new(func, Map::new())
     }
 }
 ```
@@ -243,13 +247,41 @@ impl<M: Memory> Machine<M> {
         self.threads[self.active_thread]
     }
 
-    pub fn spawn(&mut self, func: Function) -> NdResult<ThreadId> {
+    fn spawn(&mut self, func: Function, data_pointer: Value<M>, data_ptr_ty: Type) -> NdResult<ThreadId> {
         let thread_id = ThreadId::from(self.threads.len());
-        self.threads.push(Thread::new(func));
+
+        let mut locals = Map::new();
+
+        // Create place for data pointer and place it there.
+        let callee_local = func.args[0];
+        let callee_pty = func.locals[callee_local];
+        // Allocate place with callee layout (a lot like `StorageLive`).
+        let callee_layout = callee_pty.layout::<M::T>();
+        let p = self.mem.allocate(callee_layout.size, callee_layout.align)?;
+        locals.insert(callee_local, p);
+
+        // This logic is taken from `eval(Terminator::Call)` and `eval_argument`.
+        // FIXME: find a way to avoid the code duplication.
+        let data_ptr_pty = PlaceType::new(data_ptr_ty, M::T::PTR_ALIGN);
+        if !Self::check_abi_compatibility(data_ptr_pty, func.locals[func.args[0]]) {
+            throw_ub!("invalid first argument to `Intrinsic::Spawn`, function should take a pointer as an argument.");
+        }
+        
+        self.mem.typed_store(p, data_pointer, callee_pty, Atomicity::None).unwrap();
+
+        // Create place for return local, if needed.
+        // The return value will be ignored in `terminate_active_thread`.
+        if let Some(ret_local) = func.ret {
+            let callee_ret_layout = func.locals[ret_local].layout::<M::T>();
+            locals.insert(ret_local, self.mem.allocate(callee_ret_layout.size, callee_ret_layout.align)?);
+        }
+
+        self.threads.push(Thread::new(func, locals));
+
         ret(thread_id)
     }
 
-    pub fn join(&mut self, thread_id: ThreadId) -> NdResult {
+    fn join(&mut self, thread_id: ThreadId) -> NdResult {
         let Some(thread) = self.threads.get(thread_id) else {
             throw_ub!("`Intrinsic::Join`: join non existing thread");
         };
@@ -266,7 +298,7 @@ impl<M: Memory> Machine<M> {
         ret(())
     }
 
-    pub fn terminate_active_thread(&mut self) -> NdResult {
+    fn terminate_active_thread(&mut self, frame: StackFrame<M>) -> NdResult {
         let active = self.active_thread;
         assert!(active != 0, "the main thread cannot terminate");
 
@@ -281,6 +313,14 @@ impl<M: Memory> Machine<M> {
             }
             thread
         }).collect();
+
+        // Deallocate everything. Same as in return.
+        // FIXME: avoid duplicating this code with `Return`.
+        for (local, place) in frame.locals {
+            // A lot like `StorageDead`.
+            let layout = frame.func.locals[local].layout::<M::T>();
+            self.mem.deallocate(place, layout.size, layout.align)?;
+        }
 
         ret(())
     }

--- a/spec/lang/step.md
+++ b/spec/lang/step.md
@@ -38,9 +38,17 @@ impl<M: Memory> Machine<M> {
             thread.state == ThreadState::Enabled
         })?;
 
-        // Update current thread; remember previous thread for data race detection.
-        let prev_thread = self.active_thread;
+        // Remember threads synchronized by the previous step for data race detection
+        // after this step.
+        let mut prev_sync = self.synchronized_threads;
+        // Every thread is always synchronized with itself.
+        prev_sync.insert(self.active_thread);
+        // Reset synchronized_threads for the next step.
+        self.synchronized_threads = Set::new();
+
+        // Update current thread.
         self.active_thread = thread_id;
+
 
         // Prepare data race detection for next step.
         let prev_accesses = self.mem.reset_accesses();
@@ -59,7 +67,7 @@ impl<M: Memory> Machine<M> {
             self.eval_statement(stmt)?;
         }
 
-        self.mem.check_data_races(self.active_thread, prev_thread, prev_accesses)?;
+        self.mem.check_data_races(self.active_thread, prev_sync, prev_accesses)?;
 
         ret(())
     }

--- a/spec/lang/step.md
+++ b/spec/lang/step.md
@@ -98,6 +98,12 @@ impl<M: Memory> Machine<M> {
                     provenance: None,
                 })
             },
+            Constant::Null => {
+                Value::Ptr(Pointer {
+                    addr: Address::ZERO,
+                    provenance: None,
+                })
+            }
             Constant::Variant { idx, data } => {
                 let data = self.eval_constant(data)?;
                 Value::Variant { idx, data }
@@ -610,7 +616,7 @@ impl<M: Memory> Machine<M> {
             // Therefore the thread must terminate now.
             assert_eq!(Int::ZERO, self.active_thread().stack.len());
 
-            return self.terminate_active_thread();
+            return self.terminate_active_thread(frame);
         };
         // If there is caller_return_info, there must be a caller.
         assert!(self.active_thread().stack.len() > 0);

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -73,6 +73,9 @@ pub enum Constant {
     GlobalPointer(Relocation),
     /// A pointer pointing to a function.
     FnPointer(FnName),
+    /// The null pointer, pointing to address 0.
+    /// FIXME: generalize this to pointers from arbitrary constant integers.
+    Null,
 
     /// A variant of a sum type, used for enums.
     // TODO Variant shouldn't be a Constant, but rather a ValueExpr.

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -157,6 +157,7 @@ impl Constant {
             (Constant::FnPointer(fn_name), Type::Ptr(_)) => {
                 ensure(prog.functions.contains_key(fn_name))?;
             }
+            (Constant::Null, Type::Ptr(_)) => {}
             _ => throw!(),
         }
 

--- a/spec/mem/atomic.md
+++ b/spec/mem/atomic.md
@@ -110,8 +110,8 @@ pub type ThreadId = Int;
 
 impl<M: Memory> AtomicMemory<M> {
     /// Given a list of previous accesses, checks if any of the current accesses is in a data race with any of those.
-    pub fn check_data_races(&self, current_thread: ThreadId, prev_thread: ThreadId, prev_accesses: List<Access>) -> Result {
-        if current_thread == prev_thread { return Ok(()) }
+    pub fn check_data_races(&self, current_thread: ThreadId, prev_sync_threads: Set<ThreadId>, prev_accesses: List<Access>) -> Result {
+        if prev_sync_threads.contains(current_thread) { return Ok(()) }
 
         for access in self.accesses {
             if prev_accesses.any(|prev_access| access.races(prev_access)) {

--- a/tooling/minitest/src/deadlock/join_lock.rs
+++ b/tooling/minitest/src/deadlock/join_lock.rs
@@ -13,17 +13,18 @@ fn deadlock() {
     let b1 = block!( acquire(load(global::<u32>(0)), 2) );
     let b2 = block!(
         storage_live(0),
-        spawn(fn_ptr(1), Some(local(0)), 3)
+        spawn(fn_ptr(1), null(), Some(local(0)), 3)
     );
     let b3 = block!( join(load(local(0)), 4) );
     let b4 = block!( release(load(global::<u32>(0)), 5) );
     let b5 = block!( exit() );
     let main = function(Ret::No, 0, &locals, &[b0, b1, b2, b3, b4, b5]);
 
+    let locals = [<()>::get_ptype(), <*const ()>::get_ptype()];
     let b0 = block!( acquire(load(global::<u32>(0)), 1) );
     let b1 = block!( release(load(global::<u32>(0)), 2) );
     let b2 = block!( return_() );
-    let second = function(Ret::No, 0, &[], &[b0,b1,b2]);
+    let second = function(Ret::Yes, 1, &locals, &[b0,b1,b2]);
 
     // global(0) is used as a lock. We store the lock id there.
     let globals = [global_int::<u32>()];

--- a/tooling/minitest/src/pass/concurrency.rs
+++ b/tooling/minitest/src/pass/concurrency.rs
@@ -7,6 +7,7 @@ fn arbitrary_order() {
 
     /// A function that writes 1 to the global(1).
     fn write_1() -> Function {
+        let locals = [<()>::get_ptype(), <*const ()>::get_ptype()];
         let b0 = block!(
             acquire(load(global::<u32>(0)), 1)
         );
@@ -16,7 +17,7 @@ fn arbitrary_order() {
         );
         let b2 = block!(return_());
 
-        function(Ret::No, 0, &[], &[b0, b1, b2])
+        function(Ret::Yes, 1, &locals, &[b0, b1, b2])
     }
 
     // Main function, creates a lock and a thread.
@@ -34,7 +35,7 @@ fn arbitrary_order() {
     // The function given to it tries to write 1.
     let b1 = block!(
         storage_live(0),
-        spawn(fn_ptr(1), Some(local(0)), 2)
+        spawn(fn_ptr(1), null(), Some(local(0)), 2)
     );
 
     // Write 2 to global(1) within critical section.

--- a/tooling/minitest/src/pass/lock_handover.rs
+++ b/tooling/minitest/src/pass/lock_handover.rs
@@ -34,20 +34,19 @@ fn lock_handover() {
         storage_live(1),
         create_lock(global::<u32>(0), 1),
     );
-    let b1 = block!( spawn(fn_ptr(1), Some(local(0)), 2) );
+    let b1 = block!( spawn(fn_ptr(1), null(), Some(local(0)), 2) );
     let b2 = block!( call(2, &[], Some(local(1)), Some(3)));
     let b3 = block!( join(load(local(0)), 4) );
     let b4 = block!( exit() );
     let main = function(Ret::No, 0, &locals, &[b0,b1,b2,b3,b4]);
     
-    let locals = [<()>::get_ptype()];
+    let locals = [<()>::get_ptype(), <*const ()>::get_ptype()];
 
     let b0 = block!(
-        storage_live(0),
         call(2, &[], Some(local(0)), Some(1))
     );
     let b1 = block!( return_() );
-    let second = function(Ret::No, 0, &locals, &[b0,b1]);
+    let second = function(Ret::Yes, 1, &locals, &[b0,b1]);
 
     let globals = [global_int::<u32>()];
 

--- a/tooling/minitest/src/pass/lock_issue.rs
+++ b/tooling/minitest/src/pass/lock_issue.rs
@@ -1,0 +1,70 @@
+use crate::*;
+
+#[test]
+/// What this test wants to check is wether there can be a data race
+/// after a lock handover.
+/// 
+/// let global_0 = 0;
+/// let global_1 = null;
+/// 
+/// fn critical() {
+///     acquire(global_0);
+///     atomic_write(global_1, &global_0);
+///     release(*global_1)
+/// }
+/// 
+/// fn second() {
+///     critical();
+/// }
+/// 
+/// fn main() {
+///     global_0 = create_lock();
+///     let id = spawn(second, null);
+///     critical();
+///     join(id);
+/// }
+/// 
+/// If a handover occurs and data race detection does not synchronize the acquirer,
+/// it immediatly writing to global_1 would be a data race with the release.
+fn lock_issue() {
+    let locals = [<()>::get_ptype()];
+
+    let ptr_ty = <*const u32>::get_type();
+
+    let p_ptype = <u32>::get_ptype();
+    
+    let b0 = block!(
+        acquire(load(global::<u32>(0)), 1) 
+    );
+    let b1 = block!( atomic_write(addr_of(global::<*const u32>(1), <*const *const u32>::get_type()), addr_of(global::<u32>(0), ptr_ty), 2));
+    let b2 = block!( release(load(deref(load(global::<*const u32>(1)), p_ptype)), 3) );
+    let b3 = block!( return_() );
+    let critical = function(Ret::Yes, 0, &locals, &[b0,b1,b2,b3]);
+
+
+    let locals = [<u32>::get_ptype(), <()>::get_ptype()];
+    
+    let b0 = block!(
+        storage_live(0),
+        storage_live(1),
+        create_lock(global::<u32>(0), 1),
+    );
+    let b1 = block!( spawn(fn_ptr(1), null(), Some(local(0)), 2) );
+    let b2 = block!( call(2, &[], Some(local(1)), Some(3)));
+    let b3 = block!( join(load(local(0)), 4) );
+    let b4 = block!( exit() );
+    let main = function(Ret::No, 0, &locals, &[b0,b1,b2,b3,b4]);
+    
+    let locals = [<()>::get_ptype(), <*const ()>::get_ptype()];
+
+    let b0 = block!(
+        call(2, &[], Some(local(0)), Some(1))
+    );
+    let b1 = block!( return_() );
+    let second = function(Ret::Yes, 1, &locals, &[b0,b1]);
+
+    let globals = [global_int::<u32>(), global_ptr::<u32>()];
+
+    let p = program_with_globals(&[main, second, critical], &globals);
+    assert_eq!(run_program(p), TerminationInfo::MachineStop);
+}

--- a/tooling/minitest/src/pass/mod.rs
+++ b/tooling/minitest/src/pass/mod.rs
@@ -5,3 +5,5 @@ mod zst_array;
 mod dynamic_memory;
 mod concurrency;
 mod lock_handover;
+mod spawn_spurious_race;
+mod lock_issue;

--- a/tooling/minitest/src/pass/spawn_spurious_race.rs
+++ b/tooling/minitest/src/pass/spawn_spurious_race.rs
@@ -1,0 +1,50 @@
+use crate::*;
+
+/// The program written out:
+/// fn main() {
+///     let dp = allocate(sizeof *const ());
+///     *dp = dp;
+///     let id = spawn(second, *dp);
+///     join(id);
+/// }
+/// 
+/// fn second(dp) {
+///     *dp = null;
+/// }
+/// 
+/// This program should obviously not have a data race, but since
+/// we do a trace based search it could have one. This is the reason we track synchronized threads.
+#[test]
+fn thread_spawn_spurious_race() {
+    let pp_ptype = <*const *const ()>::get_ptype(); // Pointer pointer place type.
+    let locals = [pp_ptype, <u32>::get_ptype()];
+
+    let size = const_int::<usize>(<*const ()>::get_size().bytes());
+    let align = const_int::<usize>(<*const ()>::get_align().bytes());
+
+    let b0 = block!(
+        storage_live(0),
+        allocate(size, align, local(0), 1)
+    );
+    let b1 = block!(
+        storage_live(1),
+        assign(deref(load(local(0)), pp_ptype), load(local(0))),
+        spawn(fn_ptr(1), load(deref(load(local(0)), pp_ptype)), Some(local(1)), 2)
+    );
+    let b2 = block!(
+        join(load(local(1)), 3)
+    );
+    let b3 = block!( exit() );
+    let main = function(Ret::No, 0, &locals, &[b0,b1,b2,b3]);
+
+    let locals = [pp_ptype];
+    let b0 = block!(
+        assign(deref(load(local(0)), pp_ptype), null()),
+        return_(),
+    );
+    let second = function(Ret::No, 1, &locals, &[b0]);
+
+    let prog = program(&[main, second]);
+
+    assert_stop(prog);
+}

--- a/tooling/minitest/src/ub/data_race.rs
+++ b/tooling/minitest/src/ub/data_race.rs
@@ -44,7 +44,7 @@ fn racy_program(main_access: AccessPattern, s_access: AccessPattern) -> Program 
 
     let main_b0 = block!(
         storage_live(0),
-        spawn(fn_ptr(1), Some(local(0)), 1),
+        spawn(fn_ptr(1), null(), Some(local(0)), 1),
     );
     let main_b1 = access_block(main_access, 1, 2);
     let main_b2 = block!(
@@ -54,11 +54,12 @@ fn racy_program(main_access: AccessPattern, s_access: AccessPattern) -> Program 
     let main = function(Ret::No, 0, &main_locals, &[main_b0, main_b1, main_b2, main_b3]);
 
     // The second thread.
+    let s_locals = [<*const ()>::get_ptype()];
     let s_b0 = access_block(s_access, 2, 1);
     let s_b1 = block!(
         return_()
     );
-    let s_fun = function(Ret::No, 0, &[], &[s_b0, s_b1]);
+    let s_fun = function(Ret::No, 1, &s_locals, &[s_b0, s_b1]);
 
     // global(0) is needed for the race behavior; the others are used to support our operations.
     // We use globals instead of locals because locals would need an additional instruction (`storage_live`)

--- a/tooling/minitest/src/ub/join.rs
+++ b/tooling/minitest/src/ub/join.rs
@@ -1,11 +1,11 @@
 use crate::*;
 
 fn dummy_function() -> Function {
-    let locals = [<()>::get_ptype()];
+    let locals = [<*const ()>::get_ptype()];
 
     let b0 = block!(exit());
 
-    function(Ret::No, 0, &locals, &[b0])
+    function(Ret::No, 1, &locals, &[b0])
 }
 
 // Duplication of `spawn::spawn_success` for consistency.
@@ -15,7 +15,7 @@ fn join_success() {
 
     let b0 = block!(
         storage_live(0),
-        spawn(fn_ptr(1), Some(local(0)), 1),
+        spawn(fn_ptr(1), null(), Some(local(0)), 1),
     );
     let b1 = block!(
         join(load(local(0)), 2),

--- a/tooling/minitest/src/ub/spawn.rs
+++ b/tooling/minitest/src/ub/spawn.rs
@@ -137,7 +137,7 @@ fn spawn_data_ptr() {
     let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
 
     let p = program(&[f, dummy_function()]);
-    assert_ub(p, "invalid second argument to `Intrinsic::Spawn`, data pointer should be a raw pointer.");
+    assert_ub(p, "invalid second argument to `Intrinsic::Spawn`, data pointer should be a pointer.");
 }
 
 fn wrongarg() -> Function {

--- a/tooling/minitest/src/ub/spawn.rs
+++ b/tooling/minitest/src/ub/spawn.rs
@@ -1,9 +1,9 @@
 use crate::*;
 
 fn dummy_function() -> Function {
-    let locals = [<()>::get_ptype()];
+    let locals = [<*const ()>::get_ptype()];
     let b0 = block!(exit());
-    function(Ret::No, 0, &locals, &[b0])
+    function(Ret::No, 1, &locals, &[b0])
 }
 
 #[test]
@@ -12,7 +12,7 @@ fn spawn_success() {
 
     let b0 = block!(
         storage_live(0),
-        spawn(fn_ptr(1), Some(local(0)), 1),
+        spawn(fn_ptr(1), null(), Some(local(0)), 1),
     );
     let b1 = block!(
         join(load(local(0)), 2),
@@ -52,7 +52,7 @@ fn spawn_arg_value() {
     let b0 = block!(
         storage_live(0),
         assign(local(0), const_int::<u32>(0)),
-        spawn(load(local(0)), None, 1),
+        spawn(load(local(0)), null(), None, 1),
     );
     let b1 = block!(exit());
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
@@ -62,29 +62,32 @@ fn spawn_arg_value() {
 }
 
 
-fn takes_args() -> Function {
-    let locals = [<()>::get_ptype()];
+fn no_args() -> Function {
+    let locals = [];
     let b0 = block!(exit());
-    function(Ret::No, 1, &locals, &[b0])
+    function(Ret::No, 0, &locals, &[b0])
 }
 
 #[test]
-fn spawn_func_takes_args() {
+fn spawn_func_no_args() {
     let b0 = block!(
-        spawn(fn_ptr(1), None, 1),
+        spawn(fn_ptr(1), null(), None, 1),
     );
     let b1 = block!(exit());
     let f = function(Ret::No, 0, &[], &[b0, b1]);
 
-    let p = program(&[f, takes_args()]);
-    assert_ub(p, "invalid first argument to `Intrinsic::Spawn`, function takes arguments")
+    let p = program(&[f, no_args()]);
+    assert_ub(p, "invalid first argument to `Intrinsic::Spawn`, function should take one argument.")
 }
 
 
 fn returns() -> Function {
-    let locals = [<()>::get_ptype()];
-    let b0 = block!(exit());
-    function(Ret::Yes, 0, &locals, &[b0])
+    let locals = [<u32>::get_ptype(), <*const ()>::get_ptype()];
+    let b0 = block!(
+        assign(local(0), const_int::<u32>(0)),
+        return_()
+    );
+    function(Ret::Yes, 1, &locals, &[b0])
 }
 
 #[test]
@@ -92,13 +95,13 @@ fn spawn_func_returns() {
     let locals = [<()>::get_ptype()];
 
     let b0 = block!(
-        spawn(fn_ptr(1), None, 1),
+        spawn(fn_ptr(1), null(), None, 1),
     );
     let b1 = block!(exit());
     let f = function(Ret::No, 0, &locals, &[b0, b1]);
 
     let p = program(&[f, returns()]);
-    assert_ub(p, "invalid first argument to `Intrinsic::Spawn`, function returns something")
+    assert_ub(p, "invalid first argument to `Intrinsic::Spawn`, function returns something non zero sized")
 }
 
 #[test]
@@ -107,7 +110,7 @@ fn spawn_wrongreturn() {
 
     let b0 = block!(
         storage_live(0),
-        spawn(fn_ptr(1), Some(local(0)), 1),
+        spawn(fn_ptr(1), null(), Some(local(0)), 1),
     );
     let b1 = block!(
         join(load(local(0)), 2),
@@ -117,4 +120,46 @@ fn spawn_wrongreturn() {
 
     let p = program(&[f, dummy_function()]);
     assert_ub(p, "invalid return type for `Intrinsic::Spawn`");
+}
+
+#[test]
+fn spawn_data_ptr() {
+    let locals = [ <()>::get_ptype() ];
+
+    let b0 = block!(
+        storage_live(0),
+        spawn(fn_ptr(1), const_int::<usize>(0), None, 1),
+    );
+    let b1 = block!(
+        join(load(local(0)), 2),
+    );
+    let b2 = block!(exit());
+    let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
+
+    let p = program(&[f, dummy_function()]);
+    assert_ub(p, "invalid second argument to `Intrinsic::Spawn`, data pointer should be a raw pointer.");
+}
+
+fn wrongarg() -> Function {
+    let locals = [<()>::get_ptype()];
+    let b0 = block!(exit());
+    function(Ret::No, 1, &locals, &[b0])
+}
+
+#[test]
+fn spawn_wrongarg() {
+    let locals = [ <u32>::get_ptype() ];
+
+    let b0 = block!(
+        storage_live(0),
+        spawn(fn_ptr(1), null(), Some(local(0)), 1),
+    );
+    let b1 = block!(
+        join(load(local(0)), 2),
+    );
+    let b2 = block!(exit());
+    let f = function(Ret::No, 0, &locals, &[b0, b1, b2]);
+
+    let p = program(&[f, wrongarg()]);
+    assert_ub(p, "invalid first argument to `Intrinsic::Spawn`, function should take a pointer as an argument.");
 }

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -28,6 +28,10 @@ pub fn const_unit() -> ValueExpr {
     ValueExpr::Tuple(Default::default(), <()>::get_type())
 }
 
+pub fn null() -> ValueExpr {
+    ValueExpr::Constant(Constant::Null, <*const ()>::get_type())
+}
+
 pub fn load(p: PlaceExpr) -> ValueExpr {
     ValueExpr::Load {
         source: GcCow::new(p),

--- a/tooling/miniutil/src/build/global.rs
+++ b/tooling/miniutil/src/build/global.rs
@@ -10,3 +10,14 @@ pub fn global_int<T: TypeConv>() -> Global {
         align: T::get_align(),
     }
 }
+
+/// Global pointer
+pub fn global_ptr<T: TypeConv>() -> Global {
+    let bytes = List::from_elem(Some(0), <*const T>::get_size().bytes());
+
+    Global {
+        bytes,
+        relocations: list!(),
+        align: <*const T>::get_align(),
+    }
+}

--- a/tooling/miniutil/src/build/statement.rs
+++ b/tooling/miniutil/src/build/statement.rs
@@ -106,10 +106,10 @@ pub fn return_() -> Terminator {
     Terminator::Return
 }
 
-pub fn spawn(fn_ptr: ValueExpr, ret: Option<PlaceExpr>, next: u32) -> Terminator {
+pub fn spawn(fn_ptr: ValueExpr, data_ptr: ValueExpr, ret: Option<PlaceExpr>, next: u32) -> Terminator {
     Terminator::CallIntrinsic {
         intrinsic: Intrinsic::Spawn,
-        arguments: list!(fn_ptr),
+        arguments: list!(fn_ptr, data_ptr),
         ret,
         next_block: Some(BbName(Name::from_internal(next)))
     }

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -72,6 +72,7 @@ fn fmt_constant(c: Constant) -> FmtExpr {
         Constant::Bool(b) => FmtExpr::Atomic(b.to_string()),
         Constant::GlobalPointer(relocation) => fmt_relocation(relocation),
         Constant::FnPointer(fn_name) => FmtExpr::Atomic(fmt_fn_name(fn_name)),
+        Constant::Null => FmtExpr::Atomic("null".to_string()),
         Constant::Variant { .. } => panic!("enums are unsupported!"),
     }
 }


### PR DESCRIPTION
Reworked spawn to allow functions to have a zero sized return value as well as forcing functions we spawn with to take a data pointer as an argument.

Added `Constant::Null` for the case that there is no data pointer. Open to find a better solution.