### PR TITLE
re-do the way we treat alignment around places

### DIFF
--- a/spec/lang/operator.md
+++ b/spec/lang/operator.md
@@ -160,9 +160,7 @@ impl<M: Memory> Machine<M> {
             new_ptr
         };
         // `offset.abs()` is obviously positive, hence `unwrap()`.
-        // We effetively skip the align and inhabited check by using maximally permissive values.
-        let layout = Layout { size: Size::from_bytes(offset.abs()).unwrap(), align: Align::ONE, inhabited: true };
-        self.mem.dereferenceable(min_ptr, layout)?;
+        self.mem.dereferenceable(min_ptr, Size::from_bytes(offset.abs()).unwrap())?;
         // If this check passed, we are good.
         ret(new_ptr)
     }

--- a/spec/lang/representation.md
+++ b/spec/lang/representation.md
@@ -139,7 +139,7 @@ when the pointee type is uninhabited (in the sense of `!ty.inhabited()`), there 
 
 ```rust
 impl Type {
-    fn decode<M: Memory>(Type::Tuple { fields, size }: Self, bytes: List<AbstractByte<M::Provenance>>) -> Option<Value<M>> {
+    fn decode<M: Memory>(Type::Tuple { fields, size, .. }: Self, bytes: List<AbstractByte<M::Provenance>>) -> Option<Value<M>> {
         if bytes.len() != size.bytes() { throw!(); }
         ret(Value::Tuple(
             fields.try_map(|(offset, ty)| {
@@ -148,7 +148,7 @@ impl Type {
             })?
         ))
     }
-    fn encode<M: Memory>(Type::Tuple { fields, size }: Self, val: Value<M>) -> List<AbstractByte<M::Provenance>> {
+    fn encode<M: Memory>(Type::Tuple { fields, size, .. }: Self, val: Value<M>) -> List<AbstractByte<M::Provenance>> {
         let Value::Tuple(values) = val else { panic!() };
         assert_eq!(values.len(), fields.len());
         let mut bytes = list![AbstractByte::Uninit; size.bytes()];
@@ -392,31 +392,34 @@ We also use this to lift retagging from pointers to compound values.
 
 ```rust
 impl<M: Memory> AtomicMemory<M> {
-    fn typed_store(&mut self, ptr: Pointer<M::Provenance>, val: Value<M>, pty: PlaceType, atomicity: Atomicity) -> Result {
-        assert!(val.check_wf(pty.ty).is_some(), "trying to store {val:?} which is ill-formed for {:#?}", pty.ty);
-        let bytes = pty.ty.encode::<M>(val);
-        self.store(ptr, bytes, pty.align, atomicity)?;
+    fn typed_store(&mut self, ptr: Pointer<M::Provenance>, val: Value<M>, ty: Type, align: Align, atomicity: Atomicity) -> Result {
+        assert!(val.check_wf(ty).is_some(), "trying to store {val:?} which is ill-formed for {:#?}", ty);
+        let bytes = ty.encode::<M>(val);
+        self.store(ptr, bytes, align, atomicity)?;
 
         ret(())
     }
 
-    fn typed_load(&mut self, ptr: Pointer<M::Provenance>, pty: PlaceType, atomicity: Atomicity) -> Result<Value<M>> {
-        let bytes = self.load(ptr, pty.ty.size::<M::T>(), pty.align, atomicity)?;
-        ret(match pty.ty.decode::<M>(bytes) {
+    fn typed_load(&mut self, ptr: Pointer<M::Provenance>, ty: Type, align: Align, atomicity: Atomicity) -> Result<Value<M>> {
+        let bytes = self.load(ptr, ty.size::<M::T>(), align, atomicity)?;
+        ret(match ty.decode::<M>(bytes) {
             Some(val) => {
-                assert!(val.check_wf(pty.ty).is_some(), "decode returned {val:?} which is ill-formed for {:#?}", pty.ty);
+                assert!(val.check_wf(ty).is_some(), "decode returned {val:?} which is ill-formed for {:#?}", ty);
                 val
             }
-            None => throw_ub!("load at type {pty:?} but the data in memory violates the validity invariant"), // FIXME use Display instead of Debug for `pty`
+            None => throw_ub!("load at type {ty:?} but the data in memory violates the validity invariant"), // FIXME use Display instead of Debug for `ty`
         })
     }
 
+    /// Find all pointers in this value, ensure they are valid, and retag them.
     fn retag_val(&mut self, val: Value<M>, ty: Type, fn_entry: bool) -> Result<Value<M>> {
         ret(match (val, ty) {
             // no (identifiable) pointers
-            (Value::Int(..) | Value::Bool(..) | Value::Union(..), _) => val,
+            (Value::Int(..) | Value::Bool(..) | Value::Union(..), _) =>
+                val,
             // base case
-            (Value::Ptr(ptr), Type::Ptr(ptr_type)) => Value::Ptr(self.retag_ptr(ptr, ptr_type, fn_entry)?),
+            (Value::Ptr(ptr), Type::Ptr(ptr_type)) =>
+                Value::Ptr(self.retag_ptr(ptr, ptr_type, fn_entry)?),
             // recurse into tuples/arrays/enums
             (Value::Tuple(vals), Type::Tuple { fields, .. }) =>
                 Value::Tuple(vals.zip(fields).try_map(|(val, (_offset, ty))| self.retag_val(val, ty, fn_entry))?),
@@ -424,7 +427,8 @@ impl<M: Memory> AtomicMemory<M> {
                 Value::Tuple(vals.try_map(|val| self.retag_val(val, ty, fn_entry))?),
             (Value::Variant { idx, data }, Type::Enum { variants, .. }) =>
                 Value::Variant { idx, data: self.retag_val(data, variants[idx], fn_entry)? },
-            _ => panic!("this value does not have that type"),
+            _ =>
+                panic!("this value does not have that type"),
         })
     }
 }
@@ -460,22 +464,10 @@ This means we do not even need a special clause in our specification for the val
 
 ## Validity of pointers
 
-For pointers, we often want properties that go a bit beyond what can be encoded in the representation relation.
-For instance, we want to ensure references and boxes are dereferenceable.
-This does not apply at each and every typed copy (so maybe it shouldn't be called "validity"), but at least when constructing a reference (via `AddrOf`) or when using it (via `Deref`), these things should be true.
-
-```rust
-impl<M: Memory> AtomicMemory<M> {
-    fn check_pointer_dereferenceable(&self, ptr: Pointer<M::Provenance>, ptr_ty: PtrType) -> Result {
-        if let Some(pointee) = ptr_ty.safe_pointee() {
-            self.dereferenceable(ptr, pointee)?;
-        }
-        ret(())
-    }
-}
-```
-
-We expect retagging to do *at least* this check as well.
+For pointers, validity just says that `ptr_ty.addr_valid` holds for the address.
+However, we often also want to ensure that safe pointers are dereferenceable and respect the desired aliasing discipline.
+This does not apply at each and every typed copy, so it is not really part of validity, but we do ensure these properties by performing retagging (which also checks dereferencability) on each `AddrOf` and `Validate`.
+Additionally, on `Deref` of a safe pointer we double-check that it is indeed dereferenceable.
 
 ## Transmutation
 

--- a/spec/lang/step.md
+++ b/spec/lang/step.md
@@ -5,7 +5,7 @@ This file defines the heart of MiniRust: the `step` function of the `Machine`, i
 and having a collection of declarations with non-overlapping patterns for the same function that together cover all patterns.)
 
 One design decision I made here is that `eval_value` and `eval_place` return both a `Value`/`Place` and its type.
-Separately, [well-formedness](well-formed.md) defines `check_wf` functions that return a `Type`/`PlaceType`.
+Separately, [well-formedness](well-formed.md) defines `check_wf` functions that return a `Type`.
 This adds some redundancy (we basically have two definitions of what the type of an expression is).
 The separate `check_wf` enforces structurally that the type information is determined entirely statically.
 The type propagated during evaluation means we only do a single recursive traversal, and we avoid losing track of which type a given value has (which would be a problem since a value without a type is fairly meaningless).
@@ -88,6 +88,7 @@ This section defines the following function:
 
 ```rust
 impl<M: Memory> Machine<M> {
+    /// Evaluate a value expression to a value. The result value will always be well-formed for the given type.
     #[specr::argmatch(val)]
     fn eval_value(&mut self, val: ValueExpr) -> NdResult<(Value<M>, Type)> { .. }
 }
@@ -165,12 +166,22 @@ impl<M: Memory> Machine<M> {
 This loads a value from a place (often called "place-to-value coercion").
 
 ```rust
+impl<M: Memory> AtomicMemory<M> {
+    fn place_load(&mut self, place: Place<M>, ty: Type) -> Result<Value<M>> {
+        if !place.aligned {
+            throw_ub!("loading from a place based on a misaligned pointer");
+        }
+        // Alignment was already checked.
+        ret(self.typed_load(place.ptr, ty, Align::ONE, Atomicity::None)?)
+    }
+}
+
 impl<M: Memory> Machine<M> {
     fn eval_value(&mut self, ValueExpr::Load { source }: ValueExpr) -> NdResult<(Value<M>, Type)> {
-        let (p, ptype) = self.eval_place(source)?;
-        let v = self.mem.typed_load(p, ptype, Atomicity::None)?;
+        let (place, ty) = self.eval_place(source)?;
+        let v = self.mem.place_load(place, ty)?;
 
-        ret((v, ptype.ty))
+        ret((v, ty))
     }
 }
 ```
@@ -182,13 +193,18 @@ The `&` operators simply converts a place to the pointer it denotes.
 ```rust
 impl<M: Memory> Machine<M> {
     fn eval_value(&mut self, ValueExpr::AddrOf { target, ptr_ty }: ValueExpr) -> NdResult<(Value<M>, Type)> {
-        let (p, _pty) = self.eval_place(target)?;
-        // We generated a new pointer, let the aliasing model know.
+        let (place, _ty) = self.eval_place(target)?;
+        // Make sure the new pointer has a valid address.
+        // Remember that places are basically raw pointers so this is not guaranteed!
         // FIXME: test that this is UB when the pointer requires more alignment than the place,
         // and *not* UB the other way around.
-        let p = self.mem.retag_ptr(p, ptr_ty, /* fn_entry */ false)?;
+        if !ptr_ty.addr_valid(place.ptr.addr) {
+            throw_ub!("taking the address of an invalid (null, misaligned, or uninhabited) place");
+        }
+        // Let the aliasing model know. (Will also check dereferenceability if appropriate.)
+        let ptr = self.mem.retag_ptr(place.ptr, ptr_ty, /* fn_entry */ false)?;
 
-        ret((Value::Ptr(p), Type::Ptr(ptr_ty)))
+        ret((Value::Ptr(ptr), Type::Ptr(ptr_ty)))
     }
 }
 ```
@@ -226,11 +242,12 @@ For now, that is just a pointer (but this might have to change).
 Place evaluation ensures that this pointer is always dereferenceable (for the type of the place expression).
 
 ```rust
-type Place<M> = Pointer<<M as Memory>::Provenance>;
-
 impl<M: Memory> Machine<M> {
+    /// Evaluate a place expression to a place.
+    ///
+    /// Like a raw pointer, the result can be misaligned or null!
     #[specr::argmatch(place)]
-    fn eval_place(&mut self, place: PlaceExpr) -> NdResult<(Place<M>, PlaceType)> { .. }
+    fn eval_place(&mut self, place: PlaceExpr) -> NdResult<(Place<M>, Type)> { .. }
 }
 ```
 
@@ -242,12 +259,12 @@ The place for a local is directly given by the stack frame.
 
 ```rust
 impl<M: Memory> Machine<M> {
-    fn eval_place(&mut self, PlaceExpr::Local(name): PlaceExpr) -> NdResult<(Place<M>, PlaceType)> {
+    fn eval_place(&mut self, PlaceExpr::Local(name): PlaceExpr) -> NdResult<(Place<M>, Type)> {
         // This implicitly asserts that the local is live!
-        let place = self.cur_frame().locals[name];
-        let ptype = self.cur_frame().func.locals[name];
+        let ptr = self.cur_frame().locals[name];
+        let ty = self.cur_frame().func.locals[name];
 
-        ret((place, ptype))
+        ret((Place { ptr, aligned: true }, ty))
     }
 }
 ```
@@ -257,23 +274,25 @@ impl<M: Memory> Machine<M> {
 The `*` operator turns a value of pointer type into a place.
 It also ensures that the pointer is dereferenceable.
 
-- TODO: Should we ensure that `eval_place` *always* creates a dereferenceable place?
-  Then we could do the alignment check here, and wouldn't even have to track alignment in `PlaceType`.
-  Also see [this discussion](https://github.com/rust-lang/unsafe-code-guidelines/issues/319).
-
 ```rust
 impl<M: Memory> Machine<M> {
-    fn eval_place(&mut self, PlaceExpr::Deref { operand, ptype }: PlaceExpr) -> NdResult<(Place<M>, PlaceType)> {
-        let (Value::Ptr(p), Type::Ptr(ptr_type)) = self.eval_value(operand)? else {
+    fn eval_place(&mut self, PlaceExpr::Deref { operand, ty }: PlaceExpr) -> NdResult<(Place<M>, Type)> {
+        let (Value::Ptr(ptr), Type::Ptr(ptr_type)) = self.eval_value(operand)? else {
             panic!("dereferencing a non-pointer")
         };
-        // Basic check that this pointer is good for its type.
+        // We know the pointer is valid for its type, but make sure safe pointers are also dereferenceable.
         // (We don't do a full retag here, this is not considered creating a new pointer.)
         // FIXME: test that this is UB when the pointer requires more alignment than the place,
         // and *not* UB the other way around.
-        self.mem.check_pointer_dereferenceable(p, ptr_type)?;
+        if let Some(layout) = ptr_type.safe_pointee() {
+            self.mem.dereferenceable(ptr, layout.size)?;
+        }
+        // Check whether this pointer is sufficiently aligned.
+        // Don't error immediately though! Unaligned places can still be turned into raw pointers.
+        // However, they cannot be loaded from.
+        let aligned = ty.align::<M::T>().is_aligned(ptr.addr);
 
-        ret((p, ptype))
+        ret((Place { ptr, aligned }, ty))
     }
 }
 ```
@@ -282,32 +301,25 @@ impl<M: Memory> Machine<M> {
 
 ```rust
 impl<M: Memory> Machine<M> {
-    fn eval_place(&mut self, PlaceExpr::Field { root, field }: PlaceExpr) -> NdResult<(Place<M>, PlaceType)> {
-        let (root, ptype) = self.eval_place(root)?;
-        let (offset, field_ty) = match ptype.ty {
+    fn eval_place(&mut self, PlaceExpr::Field { root, field }: PlaceExpr) -> NdResult<(Place<M>, Type)> {
+        let (root, ty) = self.eval_place(root)?;
+        let (offset, field_ty) = match ty {
             Type::Tuple { fields, .. } => fields[field],
             Type::Union { fields, .. } => fields[field],
             _ => panic!("field projection on non-projectable type"),
         };
-        assert!(offset <= ptype.ty.size::<M::T>());
+        assert!(offset <= ty.size::<M::T>());
 
-        let place = self.ptr_offset_inbounds(root, offset.bytes())?;
-        let ptype = PlaceType {
-            // `offset` is statically known here (it is part of the field type)
-            // so we are fine using it for `ptype`.
-            align: ptype.align.restrict_for_offset(offset),
-            ty: field_ty,
-        };
-
-        ret((place, ptype))
+        let ptr = self.ptr_offset_inbounds(root.ptr, offset.bytes())?;
+        ret((Place { ptr, ..root }, field_ty))
     }
 
-    fn eval_place(&mut self, PlaceExpr::Index { root, index }: PlaceExpr) -> NdResult<(Place<M>, PlaceType)> {
-        let (root, ptype) = self.eval_place(root)?;
+    fn eval_place(&mut self, PlaceExpr::Index { root, index }: PlaceExpr) -> NdResult<(Place<M>, Type)> {
+        let (root, ty) = self.eval_place(root)?;
         let (Value::Int(index), _) = self.eval_value(index)? else {
             panic!("non-integer operand for array index")
         };
-        let (offset, field_ty) = match ptype.ty {
+        let (offset, field_ty) = match ty {
             Type::Array { elem, count } => {
                 if index >= 0 && index < count {
                     (index * elem.size::<M::T>(), elem)
@@ -317,17 +329,10 @@ impl<M: Memory> Machine<M> {
             }
             _ => panic!("index projection on non-indexable type"),
         };
-        assert!(offset <= ptype.ty.size::<M::T>());
+        assert!(offset <= ty.size::<M::T>());
 
-        let place = self.ptr_offset_inbounds(root, offset.bytes())?;
-        let ptype = PlaceType {
-            // We do *not* use `offset` here since that is only dynamically known.
-            // Instead use element size, which yields the lowest alignment.
-            align: ptype.align.restrict_for_offset(field_ty.size::<M::T>()),
-            ty: field_ty,
-        };
-
-        ret((place, ptype))
+        let ptr = self.ptr_offset_inbounds(root.ptr, offset.bytes())?;
+        ret((Place { ptr, ..root }, field_ty))
     }
 }
 ```
@@ -352,11 +357,22 @@ Assignment evaluates its two operands, and then stores the value into the destin
 - TODO: Should this implicitly retag, to have full `Validate` semantics?
 
 ```rust
+impl<M: Memory> AtomicMemory<M> {
+    fn place_store(&mut self, place: Place<M>, val: Value<M>, ty: Type) -> Result {
+        if !place.aligned {
+            throw_ub!("storing to a place based on a misaligned pointer");
+        }
+        // Alignment was already checked.
+        self.typed_store(place.ptr, val, ty, Align::ONE, Atomicity::None)?;
+        ret(())
+    }
+}
+
 impl<M: Memory> Machine<M> {
     fn eval_statement(&mut self, Statement::Assign { destination, source }: Statement) -> NdResult {
-        let (place, ptype) = self.eval_place(destination)?;
+        let (place, ty) = self.eval_place(destination)?;
         let (val, _) = self.eval_value(source)?;
-        self.mem.typed_store(place, val, ptype, Atomicity::None)?;
+        self.mem.place_store(place, val, ty)?;
 
         ret(())
     }
@@ -387,11 +403,11 @@ This statement asserts that a value satisfies its validity invariant, and perfor
 ```rust
 impl<M: Memory> Machine<M> {
     fn eval_statement(&mut self, Statement::Validate { place, fn_entry }: Statement) -> NdResult {
-        let (p, ptype) = self.eval_place(place)?;
+        let (place, ty) = self.eval_place(place)?;
 
-        let val = self.mem.typed_load(p, ptype, Atomicity::None)?;
-        let val = self.mem.retag_val(val, ptype.ty, fn_entry)?;
-        self.mem.typed_store(p, val, ptype, Atomicity::None)?;
+        let val = self.mem.place_load(place, ty)?;
+        let val = self.mem.retag_val(val, ty, fn_entry)?;
+        self.mem.place_store(place, val, ty)?;
 
         ret(())
     }
@@ -403,15 +419,21 @@ impl<M: Memory> Machine<M> {
 This statement replaces the contents of a place with `Uninit`.
 
 ```rust
-impl<M: Memory> Machine<M> {
-    fn deinit(&mut self, place: Place<M>, pty: PlaceType) -> NdResult {
-        self.mem.store(place, list![AbstractByte::Uninit; pty.ty.size::<M::T>().bytes()], pty.align, Atomicity::None)?;
+impl<M: Memory> AtomicMemory<M> {
+    fn deinit(&mut self, ptr: Pointer<M::Provenance>, len: Size, align: Align) -> Result {
+        self.store(ptr, list![AbstractByte::Uninit; len.bytes()], align, Atomicity::None)?;
         ret(())
     }
+}
 
+impl<M: Memory> Machine<M> {
     fn eval_statement(&mut self, Statement::Deinit { place }: Statement) -> NdResult {
-        let (p, ptype) = self.eval_place(place)?;
-        self.deinit(p, ptype)?;
+        let (p, ty) = self.eval_place(place)?;
+        if !p.aligned {
+            throw_ub!("de-initializing a place based on a misaligned pointer");
+        }
+        // Alignment was already checked.
+        self.mem.deinit(p.ptr, ty.size::<M::T>(), Align::ONE)?;
 
         ret(())
     }
@@ -426,18 +448,18 @@ These operations (de)allocate the memory backing a local.
 impl<M: Memory> StackFrame<M> {
     fn storage_live(&mut self, mem: &mut AtomicMemory<M>, local: LocalName) -> NdResult {
         let layout = self.func.locals[local].layout::<M::T>();
-        let p = mem.allocate(AllocationKind::Stack, layout.size, layout.align)?;
+        let ptr = mem.allocate(AllocationKind::Stack, layout.size, layout.align)?;
         // Here we make it a spec bug to ever mark an already live local as live.
-        self.locals.try_insert(local, p).unwrap();
+        self.locals.try_insert(local, ptr).unwrap();
         ret(())
     }
 
     fn storage_dead(&mut self, mem: &mut AtomicMemory<M>, local: LocalName) -> NdResult {
         let layout = self.func.locals[local].layout::<M::T>();
-        let p = self.locals.remove(local).unwrap();
+        let ptr = self.locals.remove(local).unwrap();
         // Here we make it a spec bug to ever mark an already dead local as dead.
         // FIXME: This does not match what rustc does: https://github.com/rust-lang/rust/issues/98896.
-        mem.deallocate(p, AllocationKind::Stack, layout.size, layout.align)?;
+        mem.deallocate(ptr, AllocationKind::Stack, layout.size, layout.align)?;
         ret(())
     }
 }
@@ -524,79 +546,90 @@ In particular, we have to initialize the new stack frame.
 /// However, when arguments get passed in registers, more details become relevant, so we require
 /// almost full structural equality.
 fn check_abi_compatibility(
-    caller_pty: PlaceType,
-    callee_pty: PlaceType,
+    caller_ty: Type,
+    callee_ty: Type,
 ) -> bool {
     // FIXME: we probably do not have enough details captured in `Type` to fully implement this.
     // For instance, what about SIMD vectors?
     // FIXME: we also reject too much here, e.g. we do not reflect `repr(transparent)`,
     // let alone `Option<&T>` being compatible with `*const T`.
-    fn check_ty_abi_compatibility(
-        caller_ty: Type,
-        callee_ty: Type,
-    ) -> bool {
-        match (caller_ty, callee_ty) {
-            (Type::Int(caller_ty), Type::Int(callee_ty)) =>
-                // The sign *does* matter for some ABIs, so we compare it as well.
-                caller_ty == callee_ty,
-            (Type::Bool, Type::Bool) =>
-                true,
-            (Type::Ptr(_), Type::Ptr(_)) =>
-                // The kind of pointer and pointee details do not matter for ABI.
-                true,
-            (Type::Tuple { fields: caller_fields, size: caller_size },
-             Type::Tuple { fields: callee_fields, size: callee_size }) =>
-                caller_fields.len() == callee_fields.len() &&
-                caller_fields.zip(callee_fields).all(|(caller_field, callee_field)|
-                    caller_field.0 == callee_field.0 && check_ty_abi_compatibility(caller_field.1, callee_field.1)
-                ) &&
-                caller_size == callee_size,
-            (Type::Array { elem: caller_elem, count: caller_count },
-             Type::Array { elem: callee_elem, count: callee_count }) =>
-                check_ty_abi_compatibility(caller_elem, callee_elem) && caller_count == callee_count,
-            (Type::Union { fields: caller_fields, chunks: caller_chunks, size: caller_size },
-             Type::Union { fields: callee_fields, chunks: callee_chunks, size: callee_size }) =>
-                caller_fields.len() == callee_fields.len() &&
-                caller_fields.zip(callee_fields).all(|(caller_field, callee_field)|
-                    caller_field.0 == callee_field.0 && check_ty_abi_compatibility(caller_field.1, callee_field.1)
-                ) &&
-                caller_chunks == callee_chunks &&
-                caller_size == callee_size,
-            (Type::Enum { variants: caller_variants, tag_encoding: caller_encoding, size: caller_size },
-             Type::Enum { variants: callee_variants, tag_encoding: callee_encoding, size: callee_size }) =>
-                caller_variants.len() == callee_variants.len() &&
-                caller_variants.zip(callee_variants).all(|(caller_field, callee_field)|
-                    check_ty_abi_compatibility(caller_field, callee_field)
-                ) &&
-                caller_encoding == callee_encoding &&
-                caller_size == callee_size,
-            // Different kind of type, definitely incompatible.
-            _ =>
-                false
-        }
+    match (caller_ty, callee_ty) {
+        (Type::Int(caller_ty), Type::Int(callee_ty)) =>
+            // The sign *does* matter for some ABIs, so we compare it as well.
+            caller_ty == callee_ty,
+        (Type::Bool, Type::Bool) =>
+            true,
+        (Type::Ptr(_), Type::Ptr(_)) =>
+            // The kind of pointer and pointee details do not matter for ABI.
+            true,
+        (Type::Tuple { fields: caller_fields, size: caller_size, align: caller_align },
+         Type::Tuple { fields: callee_fields, size: callee_size, align: callee_align }) =>
+            caller_fields.len() == callee_fields.len() &&
+            caller_fields.zip(callee_fields).all(|(caller_field, callee_field)|
+                caller_field.0 == callee_field.0 && check_abi_compatibility(caller_field.1, callee_field.1)
+            ) &&
+            caller_size == callee_size &&
+            caller_align == callee_align,
+        (Type::Array { elem: caller_elem, count: caller_count },
+         Type::Array { elem: callee_elem, count: callee_count }) =>
+            check_abi_compatibility(caller_elem, callee_elem) && caller_count == callee_count,
+        (Type::Union { fields: caller_fields, chunks: caller_chunks, size: caller_size, align: caller_align },
+         Type::Union { fields: callee_fields, chunks: callee_chunks, size: callee_size, align: callee_align }) =>
+            caller_fields.len() == callee_fields.len() &&
+            caller_fields.zip(callee_fields).all(|(caller_field, callee_field)|
+                caller_field.0 == callee_field.0 && check_abi_compatibility(caller_field.1, callee_field.1)
+            ) &&
+            caller_chunks == callee_chunks &&
+            caller_size == callee_size &&
+            caller_align == callee_align,
+        (Type::Enum { variants: caller_variants, tag_encoding: caller_encoding, size: caller_size, align: caller_align },
+         Type::Enum { variants: callee_variants, tag_encoding: callee_encoding, size: callee_size, align: callee_align }) =>
+            caller_variants.len() == callee_variants.len() &&
+            caller_variants.zip(callee_variants).all(|(caller_field, callee_field)|
+                check_abi_compatibility(caller_field, callee_field)
+            ) &&
+            caller_encoding == callee_encoding &&
+            caller_size == callee_size &&
+            caller_align == callee_align,
+        // Different kind of type, definitely incompatible.
+        _ =>
+            false
     }
-    caller_pty.align == callee_pty.align && check_ty_abi_compatibility(caller_pty.ty, callee_pty.ty)
 }
 
 impl<M: Memory> Machine<M> {
+    /// Prepare a place for being used in-place as a function argument or return value.
+    fn prepare_for_inplace_passing(
+        &mut self,
+        place: Place<M>,
+        ty: Type,
+    ) -> NdResult {
+        // Make the old value unobservable because the callee might work on it in-place.
+        // This also checks that the memory is dereferenceable, and crucially ensures we are aligned
+        // *at the given type* -- the callee does not care about packed field projections or things like that!
+        self.mem.deinit(place.ptr, ty.size::<M::T>(), ty.align::<M::T>())?;
+        // FIXME: This also needs aliasing model support.
+
+        ret(())
+    }
+
     /// A helper function to deal with `ArgumentExpr`.
     fn eval_argument(
         &mut self,
         val: ArgumentExpr,
-    ) -> NdResult<(Value<M>, PlaceType)> {
+    ) -> NdResult<(Value<M>, Type)> {
         ret(match val {
-            ArgumentExpr::ByValue(value, align) => {
-                let (value, ty) = self.eval_value(value)?;
-                (value, PlaceType::new(ty, align))
+            ArgumentExpr::ByValue(value) => {
+                self.eval_value(value)?
             }
             ArgumentExpr::InPlace(place) => {
-                let (place, pty) = self.eval_place(place)?;
-                let value = self.mem.typed_load(place, pty, Atomicity::None)?;
-                // Make the old value unobservable because the callee might work on it in-place.
-                // FIXME: This also needs aliasing model support.
-                self.deinit(place, pty)?;
+                let (place, ty) = self.eval_place(place)?;
+                // Fetch the actual value.
+                let value = self.mem.place_load(place, ty)?;
+                // Make sure we can use it in-place.
+                self.prepare_for_inplace_passing(place, ty)?;
 
-                (value, pty)
+                (value, ty)
             }
         })
     }
@@ -608,8 +641,8 @@ impl<M: Memory> Machine<M> {
         func: Function,
         return_action: ReturnAction<M>,
         caller_conv: CallingConvention,
-        caller_ret_pty: PlaceType,
-        caller_args: List<(Value<M>, PlaceType)>,
+        caller_ret_ty: Type,
+        caller_args: List<(Value<M>, Type)>,
     ) -> NdResult<StackFrame<M>> {
         let mut frame = StackFrame {
             func,
@@ -631,7 +664,7 @@ impl<M: Memory> Machine<M> {
         }
 
         // Check return place compatibility.
-        if !check_abi_compatibility(caller_ret_pty, func.locals[func.ret]) {
+        if !check_abi_compatibility(caller_ret_ty, func.locals[func.ret]) {
             throw_ub!("call ABI violation: return types are not compatible");
         }
 
@@ -639,15 +672,15 @@ impl<M: Memory> Machine<M> {
         if func.args.len() != caller_args.len() {
             throw_ub!("call ABI violation: number of arguments does not agree");
         }
-        for (callee_local, (caller_val, caller_pty)) in func.args.zip(caller_args) {
+        for (callee_local, (caller_val, caller_ty)) in func.args.zip(caller_args) {
             // Make sure caller and callee view of this are compatible.
-            if !check_abi_compatibility(caller_pty, func.locals[callee_local]) {
+            if !check_abi_compatibility(caller_ty, func.locals[callee_local]) {
                 throw_ub!("call ABI violation: argument types are not compatible");
             }
-            // Copy the value at caller (source) type -- that's necessary since it is the type the values come at.
+            // Copy the value at caller (source) type -- that's necessary since it is the type we did the load at (in `eval_argument`).
             // We know the types have compatible layout so this will fit into the allocation.
             // The local is freshly allocated so there should be no reason the store can fail.
-            self.mem.typed_store(frame.locals[callee_local], caller_val, caller_pty, Atomicity::None).unwrap();
+            self.mem.typed_store(frame.locals[callee_local], caller_val, caller_ty, caller_ty.align::<M::T>(), Atomicity::None).unwrap();
         }
 
         ret(frame)
@@ -658,11 +691,10 @@ impl<M: Memory> Machine<M> {
         Terminator::Call { callee, arguments, ret: ret_expr, next_block }: Terminator
     ) -> NdResult {
         // First evaluate the return place and remember it for `Return`. (Left-to-right!)
-        let (caller_ret_place, caller_ret_pty) = self.eval_place(ret_expr)?;
-        // To allow in-place return value passing, we proactively make the old contents
-        // of the return place unobservable.
-        // FIXME: This also needs aliasing model support.
-        self.deinit(caller_ret_place, caller_ret_pty)?;
+        let (caller_ret_place, caller_ret_ty) = self.eval_place(ret_expr)?;
+        // FIXME: should we care about `caller_ret_place.align`?
+        // Make sure we can use it in-place.
+        self.prepare_for_inplace_passing(caller_ret_place, caller_ret_ty)?;
 
         // Then evaluate the function that will be called.
         let (Value::Ptr(ptr), Type::Ptr(PtrType::FnPtr(caller_conv))) = self.eval_value(callee)? else {
@@ -676,13 +708,13 @@ impl<M: Memory> Machine<M> {
         // Set up the stack frame.
         let return_action = ReturnAction::ReturnToCaller {
             next_block,
-            ret_place: caller_ret_place,
+            ret_val_ptr: caller_ret_place.ptr,
         };
         let frame = self.create_frame(
             func,
             return_action,
             caller_conv,
-            caller_ret_pty,
+            caller_ret_ty,
             arguments,
         )?;
 
@@ -730,8 +762,9 @@ impl<M: Memory> Machine<M> {
         // Load the return value.
         // To match `Call`, and since the callee might have written to its return place using a totally different type,
         // we copy at the callee (source) type -- the one place where we ensure the return value matches that type.
-        let ret_pty = frame.func.locals[frame.func.ret];
-        let ret_val = self.mem.typed_load(frame.locals[frame.func.ret], ret_pty, Atomicity::None)?;
+        let callee_ty = frame.func.locals[frame.func.ret];
+        let align = callee_ty.align::<M::T>();
+        let ret_val = self.mem.typed_load(frame.locals[frame.func.ret], callee_ty, align, Atomicity::None)?;
 
         // Deallocate everything.
         while let Some(local) = frame.locals.keys().next() {
@@ -745,12 +778,12 @@ impl<M: Memory> Machine<M> {
                 // Therefore the thread must terminate now.
                 self.terminate_active_thread()?;
             }
-            ReturnAction::ReturnToCaller { ret_place: caller_ret_place, next_block } => {
+            ReturnAction::ReturnToCaller { ret_val_ptr: caller_ret_ptr, next_block } => {
                 // There must be a caller.
                 assert!(self.active_thread().stack.len() > 0);
                 // Store the return value where the caller wanted it.
                 // Crucially, we are doing the store at the same type as the load above.
-                self.mem.typed_store(caller_ret_place, ret_val, ret_pty, Atomicity::None)?;
+                self.mem.typed_store(caller_ret_ptr, ret_val, callee_ty, align, Atomicity::None)?;
                 // Jump to where the caller wants us to jump.
                 if let Some(next_block) = next_block {
                     self.jump_to_block(next_block)?;
@@ -777,17 +810,17 @@ impl<M: Memory> Machine<M> {
         Terminator::CallIntrinsic { intrinsic, arguments, ret: ret_expr, next_block }: Terminator
     ) -> NdResult {
         // First evaluate return place (left-to-right evaluation).
-        let (ret_place, ret_pty) = self.eval_place(ret_expr)?;
+        let (ret_place, ret_ty) = self.eval_place(ret_expr)?;
 
         // Evaluate all arguments.
         let arguments = arguments.try_map(|arg| self.eval_value(arg))?;
 
         // Run the actual intrinsic.
-        let value = self.eval_intrinsic(intrinsic, arguments, ret_pty.ty)?;
+        let value = self.eval_intrinsic(intrinsic, arguments, ret_ty)?;
 
         // Store return value.
         // `eval_inrinsic` above must guarantee that `value` has the right type.
-        self.mem.typed_store(ret_place, value, ret_pty, Atomicity::None)?;
+        self.mem.place_store(ret_place, value, ret_ty)?;
 
         // Jump to next block.
         if let Some(next_block) = next_block {

--- a/spec/lang/step.md
+++ b/spec/lang/step.md
@@ -282,9 +282,8 @@ impl<M: Memory> Machine<M> {
         };
         // We know the pointer is valid for its type, but make sure safe pointers are also dereferenceable.
         // (We don't do a full retag here, this is not considered creating a new pointer.)
-        // FIXME: test that this is UB when the pointer requires more alignment than the place,
-        // and *not* UB the other way around.
         if let Some(layout) = ptr_type.safe_pointee() {
+            assert!(layout.align.is_aligned(ptr.addr)); // this was already checked when the value got created
             self.mem.dereferenceable(ptr, layout.size)?;
         }
         // Check whether this pointer is sufficiently aligned.

--- a/spec/lang/step.md
+++ b/spec/lang/step.md
@@ -196,8 +196,6 @@ impl<M: Memory> Machine<M> {
         let (place, _ty) = self.eval_place(target)?;
         // Make sure the new pointer has a valid address.
         // Remember that places are basically raw pointers so this is not guaranteed!
-        // FIXME: test that this is UB when the pointer requires more alignment than the place,
-        // and *not* UB the other way around.
         if !ptr_ty.addr_valid(place.ptr.addr) {
             throw_ub!("taking the address of an invalid (null, misaligned, or uninhabited) place");
         }

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -100,6 +100,8 @@ pub enum UnOp {
     PtrAddr,
     /// Integer-to-pointer cast (uses previously exposed provenance)
     PtrFromExposed(PtrType),
+    /// Transmute the value to a different type.
+    Transmute(Type),
 }
 
 pub enum BinOpInt {

--- a/spec/lang/syntax.md
+++ b/spec/lang/syntax.md
@@ -155,7 +155,7 @@ pub enum PlaceExpr {
         #[specr::indirection]
         operand: ValueExpr,
         // The type of the newly created place.
-        ptype: PlaceType,
+        ty: Type,
     },
     /// Project to a field.
     Field {
@@ -256,11 +256,10 @@ pub enum Terminator {
 /// Function arguments can be passed by-value or in-place.
 pub enum ArgumentExpr {
     /// Pass a copy of this value to the function.
-    /// The alignment must match the one that the callee expects the argument to be passed at.
     ///
     /// Technically this could be encoded by generating a fresh temporary, copying the value there, and doing in-place passing.
     /// FIXME: is it worth providing this mode anyway?
-    ByValue(ValueExpr, Align),
+    ByValue(ValueExpr),
     /// Pass the argument value in-place; the contents of this place may be altered arbitrarily by the callee.
     InPlace(PlaceExpr),
 }
@@ -313,7 +312,7 @@ pub struct BbName(pub libspecr::Name);
 /// A MiniRust function.
 pub struct Function {
     /// The locals of this function, and their type.
-    pub locals: Map<LocalName, PlaceType>,
+    pub locals: Map<LocalName, Type>,
     /// A list of locals that are initially filled with the function arguments.
     pub args: List<LocalName>,
     /// The name of a local that holds the return value when the function returns.
@@ -341,7 +340,7 @@ pub struct Global {
     /// together with an offset, expressing where this allocation should put the pointer.
     /// Note that the pointers created due to relocations overwrite the data given by `bytes`.
     pub relocations: List<(Size, Relocation)>,
-    /// The align with which this global shall be allocated.
+    /// The alignment with which this global shall be allocated.
     pub align: Align,
 }
 

--- a/spec/lang/values.md
+++ b/spec/lang/values.md
@@ -27,3 +27,13 @@ enum Value<M: Memory> {
 The point of this type is to capture the mathematical concepts that are represented by the data we store in memory by defining a [representation relation](representation.md).
 The definition is likely incomplete, and even if it was complete now, we might expand it as Rust grows.
 That is okay; all previously defined representation relations are still well-defined when the domain grows, the newly added values will just not be valid for old types as one would expect.
+
+We also define the values that come out of place evaluation, called *places*:
+they store a pointer to memory, and a boolean flag indicating whether when this place was initially created, it had sufficient alignment.
+
+```rust
+struct Place<M: Memory> {
+    ptr: Pointer<M::Provenance>,
+    aligned: bool,
+}
+```

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -32,9 +32,6 @@ impl IntType {
 impl Layout {
     fn check_wf<T: Target>(self) -> Option<()> {
         // We do *not* require that size is a multiple of align!
-        // To represent e.g. the PlaceType of an `i32` at offset 0 in a
-        // type that is `align(16)`, we have to be able to talk about types
-        // with size 4 and alignment 16.
         ensure(T::valid_size(self.size))?;
 
         ret(())
@@ -69,7 +66,7 @@ impl Type {
             Ptr(ptr_type) => {
                 ptr_type.check_wf::<T>()?;
             }
-            Tuple { mut fields, size } => {
+            Tuple { mut fields, size, align: _ } => {
                 // The fields must not overlap.
                 // We check fields in the order of their (absolute) offsets.
                 fields.sort_by_key(|(offset, _ty)| offset);
@@ -89,7 +86,7 @@ impl Type {
                 ensure(count >= 0)?;
                 elem.check_wf::<T>()?;
             }
-            Union { fields, size, chunks } => {
+            Union { fields, size, chunks, align: _ } => {
                 // The fields may overlap, but they must all fit the size.
                 for (offset, ty) in fields {
                     ty.check_wf::<T>()?;
@@ -111,22 +108,13 @@ impl Type {
                 // And they must all fit into the size.
                 ensure(size >= last_end)?;
             }
-            Enum { variants, size, tag_encoding: _ } => {
+            Enum { variants, size, tag_encoding: _, align: _ } => {
                 for variant in variants {
                     variant.check_wf::<T>()?;
                     ensure(size >= variant.size::<T>())?;
                 }
             }
         }
-
-        ret(())
-    }
-}
-
-impl PlaceType {
-    fn check_wf<T: Target>(self) -> Option<()> {
-        let PlaceType { ty, align: _ } = self;
-        ty.check_wf::<T>()?;
 
         ret(())
     }
@@ -168,7 +156,8 @@ impl Constant {
 }
 
 impl ValueExpr {
-    fn check_wf<T: Target>(self, locals: Map<LocalName, PlaceType>, prog: Program) -> Option<Type> {
+    #[allow(unused_braces)]
+    fn check_wf<T: Target>(self, locals: Map<LocalName, Type>, prog: Program) -> Option<Type> {
         use ValueExpr::*;
         ret(match self {
             Constant(value, ty) => {
@@ -180,7 +169,7 @@ impl ValueExpr {
                 t.check_wf::<T>()?;
 
                 match t {
-                    Type::Tuple { fields, size: _ } => {
+                    Type::Tuple { fields, .. } => {
                         ensure(exprs.len() == fields.len())?;
                         for (e, (_offset, ty)) in exprs.zip(fields) {
                             let checked = e.check_wf::<T>(locals, prog)?;
@@ -213,8 +202,7 @@ impl ValueExpr {
                 union_ty
             }
             Load { source } => {
-                let ptype = source.check_wf::<T>(locals, prog)?;
-                ptype.ty
+                source.check_wf::<T>(locals, prog)?
             }
             AddrOf { target, ptr_ty } => {
                 target.check_wf::<T>(locals, prog)?;
@@ -272,42 +260,32 @@ impl ValueExpr {
 }
 
 impl PlaceExpr {
-    fn check_wf<T: Target>(self, locals: Map<LocalName, PlaceType>, prog: Program) -> Option<PlaceType> {
+    fn check_wf<T: Target>(self, locals: Map<LocalName, Type>, prog: Program) -> Option<Type> {
         use PlaceExpr::*;
         ret(match self {
             Local(name) => locals.get(name)?,
-            Deref { operand, ptype } => {
-                let ty = operand.check_wf::<T>(locals, prog)?;
-                ensure(matches!(ty, Type::Ptr(_)))?;
+            Deref { operand, ty } => {
+                let op_ty = operand.check_wf::<T>(locals, prog)?;
+                ensure(matches!(op_ty, Type::Ptr(_)))?;
                 // No check of how the alignment changes here -- that is purely a runtime constraint.
-                ptype
+                ty
             }
             Field { root, field } => {
                 let root = root.check_wf::<T>(locals, prog)?;
-                let (offset, field_ty) = match root.ty {
+                let (_offset, field_ty) = match root {
                     Type::Tuple { fields, .. } => fields.get(field)?,
                     Type::Union { fields, .. } => fields.get(field)?,
                     _ => throw!(),
                 };
-                PlaceType {
-                    align: root.align.restrict_for_offset(offset),
-                    ty: field_ty,
-                }
+                field_ty
             }
             Index { root, index } => {
                 let root = root.check_wf::<T>(locals, prog)?;
                 let index = index.check_wf::<T>(locals, prog)?;
                 ensure(matches!(index, Type::Int(_)))?;
-                let field_ty = match root.ty {
+                match root {
                     Type::Array { elem, .. } => elem,
                     _ => throw!(),
-                };
-                // We might be adding a multiple of `field_ty.size`, so we have to
-                // lower the alignment compared to `root`. `restrict_for_offset`
-                // is good for any multiple of that offset as well.
-                PlaceType {
-                    align: root.align.restrict_for_offset(field_ty.size::<T>()),
-                    ty: field_ty,
                 }
             }
         })
@@ -315,10 +293,10 @@ impl PlaceExpr {
 }
 
 impl ArgumentExpr {
-    fn check_wf<T: Target>(self, locals: Map<LocalName, PlaceType>, prog: Program) -> Option<Type> {
+    fn check_wf<T: Target>(self, locals: Map<LocalName, Type>, prog: Program) -> Option<Type> {
         ret(match self {
-            ArgumentExpr::ByValue(value, _align) => value.check_wf::<T>(locals, prog)?,
-            ArgumentExpr::InPlace(place) => place.check_wf::<T>(locals, prog)?.ty
+            ArgumentExpr::ByValue(value) => value.check_wf::<T>(locals, prog)?,
+            ArgumentExpr::InPlace(place) => place.check_wf::<T>(locals, prog)?
         })
     }
 }
@@ -335,16 +313,16 @@ impl Statement {
     /// This returns the adjusted live local mapping after the statement.
     fn check_wf<T: Target>(
         self,
-        mut live_locals: Map<LocalName, PlaceType>,
+        mut live_locals: Map<LocalName, Type>,
         func: Function,
         prog: Program,
-    ) -> Option<Map<LocalName, PlaceType>> {
+    ) -> Option<Map<LocalName, Type>> {
         use Statement::*;
         ret(match self {
             Assign { destination, source } => {
                 let left = destination.check_wf::<T>(live_locals, prog)?;
                 let right = source.check_wf::<T>(live_locals, prog)?;
-                ensure(left.ty == right)?;
+                ensure(left == right)?;
                 live_locals
             }
             Expose { value } => {
@@ -382,7 +360,7 @@ impl Terminator {
     /// Returns the successor basic blocks that need to be checked next.
     fn check_wf<T: Target>(
         self,
-        live_locals: Map<LocalName, PlaceType>,
+        live_locals: Map<LocalName, Type>,
         prog: Program,
     ) -> Option<List<BbName>> {
         use Terminator::*;
@@ -435,13 +413,13 @@ impl Terminator {
 impl Function {
     fn check_wf<T: Target>(self, prog: Program) -> Option<()> {
         // Ensure all locals have a valid type.
-        for pty in self.locals.values() {
-            pty.check_wf::<T>()?;
+        for ty in self.locals.values() {
+            ty.check_wf::<T>()?;
         }
 
         // Construct initially live locals.
         // Also ensures that return and argument locals must exist.
-        let mut start_live: Map<LocalName, PlaceType> = Map::new();
+        let mut start_live: Map<LocalName, Type> = Map::new();
         start_live.try_insert(self.ret, self.locals.get(self.ret)?).ok()?;
         for arg in self.args {
             // Also ensures that no two arguments refer to the same local.
@@ -451,7 +429,7 @@ impl Function {
         // Check the basic blocks. They can be cyclic, so we keep a worklist of
         // which blocks we still have to check. We also track the live locals
         // they start out with.
-        let mut bb_live_at_entry: Map<BbName, Map<LocalName, PlaceType>> = Map::new();
+        let mut bb_live_at_entry: Map<BbName, Map<LocalName, Type>> = Map::new();
         bb_live_at_entry.insert(self.start, start_live);
         let mut todo = list![self.start];
         while let Some(block_name) = todo.pop_front() {

--- a/spec/lang/well-formed.md
+++ b/spec/lang/well-formed.md
@@ -230,6 +230,11 @@ impl ValueExpr {
                         ensure(operand == Type::Int(IntType { signed: Unsigned, size: T::PTR_SIZE }))?;
                         Type::Ptr(ptr_ty)
                     }
+                    Transmute(new_ty) => {
+                        // Transmutation requires the sizes to match.
+                        ensure(operand.size::<T>() == new_ty.size::<T>());
+                        new_ty
+                    }
                 }
             }
             BinOp { operator, left, right } => {

--- a/spec/mem/atomic.md
+++ b/spec/mem/atomic.md
@@ -86,10 +86,10 @@ impl<M: Memory> AtomicMemory<M> {
         self.memory.load(ptr, len, align)
     }
 
-    /// Test whether the given pointer is dereferenceable for the given layout.
+    /// Test whether the given pointer is dereferenceable for the given size.
     /// Raises UB if that is not the case.
-    pub fn dereferenceable(&self, ptr: Pointer<M::Provenance>, layout: Layout) -> Result {
-        self.memory.dereferenceable(ptr, layout)
+    pub fn dereferenceable(&self, ptr: Pointer<M::Provenance>, len: Size) -> Result {
+        self.memory.dereferenceable(ptr, len)
     }
 
     /// Return the retagged pointer.

--- a/spec/prelude/target.md
+++ b/spec/prelude/target.md
@@ -11,6 +11,10 @@ pub trait Target {
     const PTR_SIZE: Size;
     const PTR_ALIGN: Align;
 
+    /// The maximum alignment of integer types.
+    /// Smaller types are aligned to their size.
+    const INT_MAX_ALIGN: Align;
+
     /// The endianess used for encoding multi-byte integer values (and pointers).
     const ENDIANNESS: Endianness;
 
@@ -31,6 +35,7 @@ pub struct x86_64;
 impl Target for x86_64 {
     const PTR_SIZE: Size = Size::from_bits_const(64).unwrap();
     const PTR_ALIGN: Align = Align::from_bits_const(64).unwrap();
+    const INT_MAX_ALIGN: Align = Align::from_bits_const(64).unwrap();
     const ENDIANNESS: Endianness = LittleEndian;
 
     const MAX_ATOMIC_SIZE: Size = Size::from_bits_const(64).unwrap();

--- a/tooling/minimize/src/bb.rs
+++ b/tooling/minimize/src/bb.rs
@@ -144,11 +144,7 @@ fn translate_call<'cx, 'tcx>(
 
         let args: List<_> = args.iter().map(|op| match op {
             rs::Operand::Move(place) => ArgumentExpr::InPlace(translate_place(place, fcx)),
-            op => {
-                let ty = op.ty(&fcx.body, fcx.cx.tcx);
-                let align = layout_of(ty, fcx.cx.tcx).align;
-                ArgumentExpr::ByValue(translate_operand(op, fcx), align)
-            },
+            op => ArgumentExpr::ByValue(translate_operand(op, fcx)),
         }).collect();
 
         

--- a/tooling/minimize/src/constant.rs
+++ b/tooling/minimize/src/constant.rs
@@ -79,13 +79,13 @@ fn relocation_to_value_expr<'cx, 'tcx>(
 ) -> ValueExpr {
     let expr = Constant::GlobalPointer(rel);
 
-    let pty = place_type_of(ty, fcx);
+    let ty = translate_ty(ty, fcx.cx.tcx);
     let ptr_ty = Type::Ptr(PtrType::Raw);
 
     let expr = ValueExpr::Constant(expr, ptr_ty);
     let expr = PlaceExpr::Deref {
         operand: GcCow::new(expr),
-        ptype: pty,
+        ty,
     };
     ValueExpr::Load {
         source: GcCow::new(expr),

--- a/tooling/minimize/src/program.rs
+++ b/tooling/minimize/src/program.rs
@@ -106,7 +106,7 @@ fn mk_start_fn(entry: u32) -> Function {
     blocks.insert(b1_name, b1);
 
     let mut locals = Map::new();
-    locals.insert(l0_name, <() as build::TypeConv>::get_ptype());
+    locals.insert(l0_name, <() as build::TypeConv>::get_type());
 
     Function {
         locals,
@@ -133,7 +133,7 @@ pub struct FnCtxt<'cx, 'tcx> {
     // associate names for each basic block.
     pub bb_name_map: HashMap<rs::BasicBlock, BbName>,
 
-    pub locals: Map<LocalName, PlaceType>,
+    pub locals: Map<LocalName, Type>,
     pub blocks: Map<BbName, BasicBlock>,
 }
 
@@ -256,16 +256,8 @@ pub fn translate_calling_convention(conv: rs::Conv) -> CallingConvention {
     }
 }
 
-fn translate_local<'tcx>(local: &rs::LocalDecl<'tcx>, tcx: rs::TyCtxt<'tcx>) -> PlaceType {
-    let ty = translate_ty(local.ty, tcx);
-
-    // generics have already been resolved before, so `ParamEnv::empty()` is correct.
-    let a = rs::ParamEnv::empty().and(local.ty);
-    let layout = tcx.layout_of(a).unwrap().layout;
-    let align = layout.align().abi;
-    let align = translate_align(align);
-
-    PlaceType { ty, align }
+fn translate_local<'tcx>(local: &rs::LocalDecl<'tcx>, tcx: rs::TyCtxt<'tcx>) -> Type {
+    translate_ty(local.ty, tcx)
 }
 
 pub fn translate_align(align: rs::Align) -> Align {

--- a/tooling/minimize/src/rvalue.rs
+++ b/tooling/minimize/src/rvalue.rs
@@ -251,9 +251,9 @@ pub fn translate_place<'cx, 'tcx>(
                     fcx.cx.tcx,
                 )
                 .ty;
-                let ptype = place_type_of(ty, fcx);
+                let ty = translate_ty(ty, fcx.cx.tcx);
 
-                expr = PlaceExpr::Deref { operand: x, ptype };
+                expr = PlaceExpr::Deref { operand: x, ty };
             }
             rs::ProjectionElem::Index(loc) => {
                 let i = PlaceExpr::Local(fcx.local_name_map[&loc]);
@@ -269,11 +269,4 @@ pub fn translate_place<'cx, 'tcx>(
         }
     }
     expr
-}
-
-pub fn place_type_of<'cx, 'tcx>(ty: rs::Ty<'tcx>, fcx: &mut FnCtxt<'cx, 'tcx>) -> PlaceType {
-    let align = layout_of(ty, fcx.cx.tcx).align;
-    let ty = translate_ty(ty, fcx.cx.tcx);
-
-    PlaceType { ty, align }
 }

--- a/tooling/minimize/tests/ub/inv_bool.stderr
+++ b/tooling/minimize/tests/ub/inv_bool.stderr
@@ -1,1 +1,1 @@
-UB: load at type PlaceType { ty: Bool, align: Align(1 bytes) } but the data in memory violates the validity invariant
+UB: load at type Bool but the data in memory violates the validity invariant

--- a/tooling/minimize/tests/ub/unaligned.stderr
+++ b/tooling/minimize/tests/ub/unaligned.stderr
@@ -1,1 +1,1 @@
-UB: pointer is insufficiently aligned
+UB: loading from a place based on a misaligned pointer

--- a/tooling/minitest/src/lib.rs
+++ b/tooling/minitest/src/lib.rs
@@ -29,6 +29,24 @@ pub fn assert_ub(prog: Program, msg: &str) {
 }
 
 #[track_caller]
+pub fn assert_ub_eventually(prog: Program, attempts: usize, msg: &str) {
+    let msg = minirust_rs::prelude::String::from_internal(msg.to_string());
+    for _ in 0..attempts {
+        match run_program(prog) {
+            TerminationInfo::MachineStop => continue,
+            TerminationInfo::Ub(res) if res == msg => {
+                // Got the expected result.
+                return
+            }
+            termination_info => {
+                panic!("unexpected outcome in `assert_ub_eventually`: {:?}", termination_info);
+            }
+        }
+    }
+    panic!("did not get expected output after {} attempts", attempts);
+}
+
+#[track_caller]
 pub fn assert_ill_formed(prog: Program) {
     assert_eq!(run_program(prog), TerminationInfo::IllFormed);
 }

--- a/tooling/minitest/src/tests/align.rs
+++ b/tooling/minitest/src/tests/align.rs
@@ -3,8 +3,8 @@ use crate::*;
 #[test]
 fn manual_align() {
     let locals = &[
-        <[u8; 64]>::get_ptype(),
-        <usize>::get_ptype()
+        <[u8; 64]>::get_type(),
+        <usize>::get_type()
     ];
 
     let stmts = &[
@@ -39,7 +39,7 @@ fn manual_align() {
                     load(local(1)),
                     InBounds::Yes
                 ),
-                <u64>::get_ptype()
+                <u64>::get_type()
             ),
             const_int::<u64>(42)
         ),
@@ -59,9 +59,9 @@ fn impossible_align() {
     let align = 2u128.pow(65);
     let align = Align::from_bytes(align).unwrap();
 
-    let pty = ptype(<u8>::get_type(), align);
+    let ty = tuple_ty(&[], size(0), align);
 
-    let locals = [ pty ];
+    let locals = [ ty ];
 
     let b0 = block!(
         storage_live(0),

--- a/tooling/minitest/src/tests/align.rs
+++ b/tooling/minitest/src/tests/align.rs
@@ -75,6 +75,64 @@ fn impossible_align() {
 }
 
 #[test]
+fn load_place_misaligned() {
+    let union_ty = union_ty(&[
+            (size(0), <usize>::get_type()),
+            (size(0), <*const [i32; 0]>::get_type()),
+        ], size(8), align(8));
+
+    let locals = [ union_ty, <[i32; 0]>::get_type(), ];
+
+    let b0 = block!(
+        storage_live(0),
+        storage_live(1),
+        assign(
+            field(local(0), 0),
+            const_int::<usize>(1) // nullptr + 1
+        ),
+        assign(
+            local(1),
+            load(deref(load(field(local(0), 1)), <[i32; 0]>::get_type()))
+        ),
+        exit()
+    );
+
+    let f = function(Ret::No, 0, &locals, &[b0]);
+    let p = program(&[f]);
+    dump_program(p);
+    assert_ub(p, "loading from a place based on a misaligned pointer");
+}
+
+#[test]
+fn store_place_misaligned() {
+    let union_ty = union_ty(&[
+            (size(0), <usize>::get_type()),
+            (size(0), <*const [i32; 0]>::get_type()),
+        ], size(8), align(8));
+
+    let locals = [ union_ty, <[i32; 0]>::get_type(), ];
+
+    let b0 = block!(
+        storage_live(0),
+        storage_live(1),
+        assign(
+            field(local(0), 0),
+            const_int::<usize>(1) // nullptr + 1
+        ),
+        assign(
+            deref(load(field(local(0), 1)), <[i32; 0]>::get_type()),
+            load(local(1)),
+        ),
+        exit()
+    );
+
+    let f = function(Ret::No, 0, &locals, &[b0]);
+    let p = program(&[f]);
+    dump_program(p);
+    assert_ub(p, "storing to a place based on a misaligned pointer");
+}
+
+#[test]
 fn deref_misaligned_ref() {
     let locals = [ <*const i32>::get_type(), <*const u8>::get_type() ];
     let b0 = block!(
@@ -88,8 +146,8 @@ fn deref_misaligned_ref() {
     );
     let u8ptr = ptr_to_ptr(load(local(0)), <*const u8>::get_type());
     // make the pointer definitely not 2-aligned
-    let u8ptr = ptr_offset(u8ptr, const_int::<usize>(1), InBounds::Yes);
-    let u16ptr = ptr_to_ptr(u8ptr, <*const u16>::get_type());
+    let nonaligned = ptr_offset(u8ptr, const_int::<usize>(1), InBounds::Yes);
+    let u16ptr = ptr_to_ptr(nonaligned, <*const u16>::get_type());
     let u16ref = transmute(u16ptr, <&'static u16>::get_type());
     let b1 = block!(
         storage_live(1),
@@ -128,6 +186,76 @@ fn deref_overaligned() {
             local(2),
             // We deref a `*const u8` to a `u32` and load that but it's fine since it actually is u32-aligned.
             load(deref(u8ptr, u32::get_type())),
+        ),
+        exit(),
+    );
+    let f = function(Ret::No, 0, &locals, &[b0, b1]);
+    let p = program(&[f]);
+    assert_stop(p);
+}
+
+#[test]
+fn addr_of_misaligned_ref() {
+    let locals = [ <i32>::get_type(), <*const i32>::get_type(), <&'static u16>::get_type() ];
+    let b0 = block!(
+        storage_live(0),
+        assign(
+            local(0),
+            const_int::<i32>(0),
+        ),
+        storage_live(1),
+        assign(
+            local(1),
+            addr_of(local(1), <*const i32>::get_type()),
+        ),
+        goto(1),
+    );
+    let u8ptr = ptr_to_ptr(load(local(1)), <*const u8>::get_type());
+    // make the pointer definitely not 2-aligned
+    let nonaligned = ptr_offset(u8ptr, const_int::<usize>(1), InBounds::Yes);
+    let u16ptr = ptr_to_ptr(nonaligned, <*const u16>::get_type());
+    let b1 = block!(
+        storage_live(2),
+        assign(
+            local(2),
+            // We deref to `u8` but the type of the reference matters!
+            addr_of(deref(u16ptr, <u8>::get_type()), <&'static u16>::get_type()),
+        ),
+        exit(),
+    );
+    let f = function(Ret::No, 0, &locals, &[b0, b1]);
+    let p = program(&[f]);
+    assert_ub(p, "taking the address of an invalid (null, misaligned, or uninhabited) place");
+}
+
+/// Same test as above, but with a raw pointer it's fine.
+#[test]
+fn addr_of_misaligned_ptr() {
+    let locals = [ <i32>::get_type(), <*const i32>::get_type(), <*const u16>::get_type() ];
+    let b0 = block!(
+        storage_live(0),
+        assign(
+            local(0),
+            const_int::<i32>(0),
+        ),
+        storage_live(1),
+        assign(
+            local(1),
+            addr_of(local(1), <*const i32>::get_type()),
+        ),
+        goto(1),
+    );
+    let u8ptr = ptr_to_ptr(load(local(1)), <*const u8>::get_type());
+    // make the pointer definitely not 2-aligned
+    let nonaligned = ptr_offset(u8ptr, const_int::<usize>(1), InBounds::Yes);
+    let u16ptr = ptr_to_ptr(nonaligned, <*const u16>::get_type());
+    let b1 = block!(
+        storage_live(2),
+        assign(
+            local(2),
+            // We even addr_of to `u32` here which requires even more alignment,
+            // but it's all raw so it's fine.
+            addr_of(deref(u16ptr, <u16>::get_type()), <*const u32>::get_type()),
         ),
         exit(),
     );

--- a/tooling/minitest/src/tests/atomic.rs
+++ b/tooling/minitest/src/tests/atomic.rs
@@ -2,7 +2,7 @@ use crate::*;
 
 #[test]
 fn atomic_write_success() {
-    let locals = [<u32>::get_ptype()];
+    let locals = [<u32>::get_type()];
 
     let ptr_ty = raw_ptr_ty();
 
@@ -61,7 +61,7 @@ fn atomic_write_arg_type1() {
 
 #[test]
 fn atomic_write_arg_type_pow() {
-    let locals = [<[u8; 3]>::get_ptype()];
+    let locals = [<[u8; 3]>::get_type()];
 
     let ptr_ty = raw_ptr_ty();
     let arr = const_array(&[
@@ -89,7 +89,7 @@ fn atomic_write_arg_type_pow() {
 // This test assumes that we test on a memory with `MAX_ATOMIC_SIZE <= 8 byte`.
 #[test]
 fn atomic_write_arg_type_size() {
-    let locals = [<[u64; 2]>::get_ptype()];
+    let locals = [<[u64; 2]>::get_type()];
 
     let ptr_ty = raw_ptr_ty();
     let arr = const_array(&[
@@ -115,7 +115,7 @@ fn atomic_write_arg_type_size() {
 
 #[test]
 fn atomic_write_ret_type() {
-    let locals = [<u64>::get_ptype()];
+    let locals = [<u64>::get_type()];
 
     let ptr_ty = raw_ptr_ty();
 
@@ -138,7 +138,7 @@ fn atomic_write_ret_type() {
 
 #[test]
 fn atomic_read_success() {
-    let locals = [<u32>::get_ptype(); 2];
+    let locals = [<u32>::get_type(); 2];
 
     let ptr_ty = raw_ptr_ty();
 
@@ -163,7 +163,7 @@ fn atomic_read_success() {
 
 #[test]
 fn atomic_read_arg_count() {
-    let locals = [ <u32>::get_ptype() ];
+    let locals = [ <u32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -183,7 +183,7 @@ fn atomic_read_arg_count() {
 
 #[test]
 fn atomic_read_arg_type() {
-    let locals = [ <u32>::get_ptype() ];
+    let locals = [ <u32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -203,7 +203,7 @@ fn atomic_read_arg_type() {
 
 #[test]
 fn atomic_read_ret_type_pow() {
-    let locals = [ <()>::get_ptype() ];
+    let locals = [ <()>::get_type() ];
 
     let ptr_ty = raw_ptr_ty();
 
@@ -221,7 +221,7 @@ fn atomic_read_ret_type_pow() {
 // This test assumes that we test on a memory with `MAX_ATOMIC_SIZE <= 8 byte`.
 #[test]
 fn atomic_read_ret_type_size() {
-    let locals = [ <[u64; 2]>::get_ptype() ];
+    let locals = [ <[u64; 2]>::get_type() ];
 
     let ptr_ty = raw_ptr_ty();
 

--- a/tooling/minitest/src/tests/call.rs
+++ b/tooling/minitest/src/tests/call.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
 fn other_f() -> Function {
-    let locals = [<()>::get_ptype(); 2];
+    let locals = [<()>::get_type(); 2];
     let b0 = block!(exit());
 
     function(Ret::Yes, 1, &locals, &[b0])
@@ -9,13 +9,13 @@ fn other_f() -> Function {
 
 #[test]
 fn call_success() {
-    let locals = [<()>::get_ptype()];
+    let locals = [<()>::get_type()];
 
     let b0 = block!(
         storage_live(0),
         Terminator::Call {
             callee: fn_ptr(1),
-            arguments: list![by_value::<()>(const_unit())],
+            arguments: list![by_value(const_unit())],
             ret: local(0),
             next_block: Some(BbName(Name::from_internal(1))),
         }
@@ -30,13 +30,13 @@ fn call_success() {
 
 #[test]
 fn call_non_exist() {
-    let locals = [<()>::get_ptype()];
+    let locals = [<()>::get_type()];
 
     let b0 = block!(
         storage_live(0),
         Terminator::Call {
             callee: fn_ptr(1),
-            arguments: list![by_value::<()>(const_unit())],
+            arguments: list![by_value(const_unit())],
             ret: local(0),
             next_block: Some(BbName(Name::from_internal(1))),
         }
@@ -51,7 +51,7 @@ fn call_non_exist() {
 
 #[test]
 fn call_arg_count() {
-    let locals = [<()>::get_ptype()];
+    let locals = [<()>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -72,13 +72,13 @@ fn call_arg_count() {
 
 #[test]
 fn call_arg_abi() {
-    let locals = [<()>::get_ptype()];
+    let locals = [<()>::get_type()];
 
     let b0 = block!(
         storage_live(0),
         Terminator::Call {
             callee: fn_ptr(1),
-            arguments: list![by_value::<i32>(const_int::<i32>(42))],
+            arguments: list![by_value(const_int::<i32>(42))],
             ret: local(0),
             next_block: Some(BbName(Name::from_internal(1))),
         }
@@ -93,13 +93,13 @@ fn call_arg_abi() {
 
 #[test]
 fn call_ret_abi() {
-    let locals = [<i32>::get_ptype()];
+    let locals = [<i32>::get_type()];
 
     let b0 = block!(
         storage_live(0),
         Terminator::Call {
             callee: fn_ptr(1),
-            arguments: list![by_value::<()>(const_unit())],
+            arguments: list![by_value(const_unit())],
             ret: local(0),
             next_block: Some(BbName(Name::from_internal(1))),
         }

--- a/tooling/minitest/src/tests/check_ptr.rs
+++ b/tooling/minitest/src/tests/check_ptr.rs
@@ -30,35 +30,6 @@ fn check_ptr_null() {
 }
 
 #[test]
-fn check_ptr_misaligned() {
-    let union_ty = union_ty(&[
-            (size(0), <usize>::get_type()),
-            (size(0), <*const i32>::get_type()),
-        ], size(8), align(8));
-
-    let locals = [ union_ty, <i32>::get_type(), ];
-
-    let b0 = block!(
-        storage_live(0),
-        storage_live(1),
-        assign(
-            field(local(0), 0),
-            const_int::<usize>(1) // nullptr + 1
-        ),
-        assign(
-            local(1),
-            load(deref(load(field(local(0), 1)), <i32>::get_type()))
-        ),
-        exit()
-    );
-
-    let f = function(Ret::No, 0, &locals, &[b0]);
-    let p = program(&[f]);
-    dump_program(p);
-    assert_ub(p, "loading from a place based on a misaligned pointer");
-}
-
-#[test]
 fn use_after_free() {
     let locals = vec![<*const i32>::get_type()];
     let n = const_int::<usize>(4);

--- a/tooling/minitest/src/tests/check_ptr.rs
+++ b/tooling/minitest/src/tests/check_ptr.rs
@@ -5,10 +5,9 @@ fn check_ptr_null() {
     let union_ty = union_ty(&[
             (size(0), <usize>::get_type()),
             (size(0), <*const i32>::get_type()),
-        ], size(8));
-    let union_pty = ptype(union_ty, align(8));
+        ], size(8), align(8));
 
-    let locals = [ union_pty, <i32>::get_ptype(), ];
+    let locals = [ union_ty, <i32>::get_type(), ];
 
     let b0 = block!(
         storage_live(0),
@@ -19,7 +18,7 @@ fn check_ptr_null() {
         ),
         assign(
             local(1),
-            load(deref(load(field(local(0), 1)), <i32>::get_ptype()))
+            load(deref(load(field(local(0), 1)), <i32>::get_type()))
         ),
         exit()
     );
@@ -35,10 +34,9 @@ fn check_ptr_misaligned() {
     let union_ty = union_ty(&[
             (size(0), <usize>::get_type()),
             (size(0), <*const i32>::get_type()),
-        ], size(8));
-    let union_pty = ptype(union_ty, align(8));
+        ], size(8), align(8));
 
-    let locals = [ union_pty, <i32>::get_ptype(), ];
+    let locals = [ union_ty, <i32>::get_type(), ];
 
     let b0 = block!(
         storage_live(0),
@@ -49,7 +47,7 @@ fn check_ptr_misaligned() {
         ),
         assign(
             local(1),
-            load(deref(load(field(local(0), 1)), <i32>::get_ptype()))
+            load(deref(load(field(local(0), 1)), <i32>::get_type()))
         ),
         exit()
     );
@@ -57,18 +55,18 @@ fn check_ptr_misaligned() {
     let f = function(Ret::No, 0, &locals, &[b0]);
     let p = program(&[f]);
     dump_program(p);
-    assert_ub(p, "pointer is insufficiently aligned");
+    assert_ub(p, "loading from a place based on a misaligned pointer");
 }
 
 #[test]
 fn use_after_free() {
-    let locals = vec![<*const i32>::get_ptype()];
+    let locals = vec![<*const i32>::get_type()];
     let n = const_int::<usize>(4);
     let b0 = block!(storage_live(0), allocate(n, n, local(0), 1));
     let b1 = block!(deallocate(load(local(0)), n, n, 2));
     let b2 = block!(
         assign( // write to ptr after dealloc!
-            deref(load(local(0)), <i32>::get_ptype()),
+            deref(load(local(0)), <i32>::get_type()),
             const_int::<i32>(42),
         ),
         exit()

--- a/tooling/minitest/src/tests/compare_exchange.rs
+++ b/tooling/minitest/src/tests/compare_exchange.rs
@@ -2,7 +2,7 @@ use crate::*;
 
 #[test]
 fn compare_exchange_success() {
-    let locals = [ <u32>::get_ptype(); 2 ];
+    let locals = [ <u32>::get_type(); 2 ];
 
     let ptr_ty = raw_ptr_ty();
 
@@ -51,7 +51,7 @@ fn compare_exchange_success() {
 
 #[test]
 fn compare_exchange_arg_count() {
-    let locals = [ <u32>::get_ptype(); 2 ];
+    let locals = [ <u32>::get_type(); 2 ];
 
     let ptr_ty = raw_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
@@ -76,7 +76,7 @@ fn compare_exchange_arg_count() {
 
 #[test]
 fn compare_exchange_arg_1_value() {
-    let locals = [ <u32>::get_ptype() ];
+    let locals = [ <u32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -91,7 +91,7 @@ fn compare_exchange_arg_1_value() {
 
 #[test]
 fn compare_exchange_ret_type() {
-    let locals = [ <[u8; 3]>::get_ptype(); 2 ];
+    let locals = [ <[u8; 3]>::get_type(); 2 ];
 
     let ptr_ty = raw_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
@@ -112,7 +112,7 @@ fn compare_exchange_ret_type() {
 
 #[test]
 fn compare_exchange_arg_1_type() {
-    let locals = [ <u32>::get_ptype(); 2 ];
+    let locals = [ <u32>::get_type(); 2 ];
 
     let ptr_ty = raw_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
@@ -132,7 +132,7 @@ fn compare_exchange_arg_1_type() {
 
 #[test]
 fn compare_exchange_arg_2_type() {
-    let locals = [ <u32>::get_ptype(); 2 ];
+    let locals = [ <u32>::get_type(); 2 ];
 
     let ptr_ty = raw_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);
@@ -152,7 +152,7 @@ fn compare_exchange_arg_2_type() {
 
 #[test]
 fn compare_exchange_arg_size_max() {
-    let locals = [ <u128>::get_ptype(); 2 ];
+    let locals = [ <u128>::get_type(); 2 ];
 
     let ptr_ty = raw_ptr_ty();
     let addr0 = addr_of(local(0), ptr_ty);

--- a/tooling/minitest/src/tests/concurrency.rs
+++ b/tooling/minitest/src/tests/concurrency.rs
@@ -7,7 +7,7 @@ fn arbitrary_order() {
 
     /// A function that writes 1 to the global(1).
     fn write_1() -> Function {
-        let locals = [<*const ()>::get_ptype()];
+        let locals = [<*const ()>::get_type()];
         let b0 = block!(
             acquire(load(global::<u32>(0)), 1)
         );
@@ -24,7 +24,7 @@ fn arbitrary_order() {
     // It then tries to write 2 to global(1).
 
     // The locals are used to store the thread ids.
-    let locals = [<u32>::get_ptype()];
+    let locals = [<u32>::get_type()];
 
     // Create the lock and store its id at global(0).
     let b0 = block!(

--- a/tooling/minitest/src/tests/data_race.rs
+++ b/tooling/minitest/src/tests/data_race.rs
@@ -40,7 +40,7 @@ fn access_block(access: AccessPattern, support_global: u32, next: u32) -> BasicB
 
 fn racy_program(main_access: AccessPattern, s_access: AccessPattern) -> Program {
     // The main thread.
-    let main_locals = [<u32>::get_ptype()];
+    let main_locals = [<u32>::get_type()];
 
     let main_b0 = block!(
         storage_live(0),
@@ -54,7 +54,7 @@ fn racy_program(main_access: AccessPattern, s_access: AccessPattern) -> Program 
     let main = function(Ret::No, 0, &main_locals, &[main_b0, main_b1, main_b2, main_b3]);
 
     // The second thread.
-    let s_locals = [<()>::get_ptype(), <*const ()>::get_ptype()];
+    let s_locals = [<()>::get_type(), <*const ()>::get_type()];
     let s_b0 = access_block(s_access, 2, 1);
     let s_b1 = block!(
         return_()

--- a/tooling/minitest/src/tests/div_zero.rs
+++ b/tooling/minitest/src/tests/div_zero.rs
@@ -2,7 +2,7 @@ use crate::*;
 
 #[test]
 fn div_zero() {
-    let locals = [<i32>::get_ptype()];
+    let locals = [<i32>::get_type()];
 
     let b0 = block!(
         storage_live(0),

--- a/tooling/minitest/src/tests/heap_intrinsics.rs
+++ b/tooling/minitest/src/tests/heap_intrinsics.rs
@@ -2,17 +2,17 @@ use crate::*;
 
 #[test]
 fn dynamic_memory() {
-    let locals = [<*const i32>::get_ptype(), <i32>::get_ptype()];
+    let locals = [<*const i32>::get_type(), <i32>::get_type()];
     let n = const_int::<usize>(4);
     let b0 = block!(storage_live(0), storage_live(1), allocate(n, n, local(0), 1)); // alloc ptr
     let b1 = block!(
         assign( // write to ptr
-            deref(load(local(0)), <i32>::get_ptype()),
+            deref(load(local(0)), <i32>::get_type()),
             const_int::<i32>(42),
         ),
         assign( // read from ptr
             local(1),
-            load(deref(load(local(0)), <i32>::get_ptype())),
+            load(deref(load(local(0)), <i32>::get_type())),
         ),
         deallocate(load(local(0)), n, n, 2)
     );
@@ -24,7 +24,7 @@ fn dynamic_memory() {
 
 #[test]
 fn alloc_argcount() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -44,7 +44,7 @@ fn alloc_argcount() {
 
 #[test]
 fn alloc_align_err() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -65,7 +65,7 @@ fn alloc_align_err() {
 
 #[test]
 fn alloc_size_err() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -86,7 +86,7 @@ fn alloc_size_err() {
 
 #[test]
 fn alloc_wrongarg1() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -108,7 +108,7 @@ fn alloc_wrongarg1() {
 
 #[test]
 fn alloc_wrongarg2() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -130,7 +130,7 @@ fn alloc_wrongarg2() {
 
 #[test]
 fn alloc_wrongreturn() {
-    let locals = [ <()>::get_ptype() ];
+    let locals = [ <()>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -151,7 +151,7 @@ fn alloc_wrongreturn() {
 
 #[test]
 fn dealloc_success() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -195,7 +195,7 @@ fn dealloc_argcount() {
 
 #[test]
 fn dealloc_align_err() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -219,7 +219,7 @@ fn dealloc_align_err() {
 
 #[test]
 fn dealloc_size_err() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -243,7 +243,7 @@ fn dealloc_size_err() {
 
 #[test]
 fn dealloc_wrongarg1() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -267,7 +267,7 @@ fn dealloc_wrongarg1() {
 
 #[test]
 fn dealloc_wrongarg2() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -291,7 +291,7 @@ fn dealloc_wrongarg2() {
 
 #[test]
 fn dealloc_wrongarg3() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -315,7 +315,7 @@ fn dealloc_wrongarg3() {
 
 #[test]
 fn dealloc_wrongreturn() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -339,7 +339,7 @@ fn dealloc_wrongreturn() {
 
 #[test]
 fn mem_dealloc_wrong_size() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -363,7 +363,7 @@ fn mem_dealloc_wrong_size() {
 
 #[test]
 fn mem_dealloc_wrong_align() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -392,10 +392,9 @@ fn mem_dealloc_inv_ptr() {
     let union_ty = union_ty(&[
             (size(0), <usize>::get_type()),
             (size(0), <*const i32>::get_type()),
-        ], size(8));
-    let union_pty = ptype(union_ty, align(8));
+        ], size(8), align(8));
 
-    let locals = [ union_pty ];
+    let locals = [ union_ty ];
 
     let b0 = block!(
         storage_live(0),
@@ -421,7 +420,7 @@ fn mem_dealloc_inv_ptr() {
 
 #[test]
 fn mem_dealloc_not_beginning() {
-    let locals = [ <*const i32>::get_ptype() ];
+    let locals = [ <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -453,7 +452,7 @@ fn mem_dealloc_not_beginning() {
 
 #[test]
 fn double_free() {
-    let locals = vec![<*const i32>::get_ptype()];
+    let locals = vec![<*const i32>::get_type()];
     let n = const_int::<usize>(4);
     let b0 = block!(storage_live(0), allocate(n, n, local(0), 1));
     let b1 = block!(deallocate(load(local(0)), n, n, 2));
@@ -466,7 +465,7 @@ fn double_free() {
 
 #[test]
 fn memory_leak() {
-    let locals = [<*mut i32>::get_ptype()];
+    let locals = [<*mut i32>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -487,7 +486,7 @@ fn memory_leak() {
 #[test]
 fn mem_dealloc_stack() {
     let n = const_int::<usize>(4); // size and align of i32
-    let locals = vec![<i32>::get_ptype()];
+    let locals = vec![<i32>::get_type()];
     let b0 = block!(
         storage_live(0),
         deallocate(

--- a/tooling/minitest/src/tests/ill_formed.rs
+++ b/tooling/minitest/src/tests/ill_formed.rs
@@ -3,7 +3,7 @@ use crate::*;
 
 #[test]
 fn dead_before_live() {
-    let locals = vec![ <bool>::get_ptype() ];
+    let locals = vec![ <bool>::get_type() ];
     let stmts = vec![storage_dead(0)];
     let p = small_program(&locals, &stmts);
     assert_ill_formed(p);
@@ -11,7 +11,7 @@ fn dead_before_live() {
 
 #[test]
 fn double_live() {
-    let locals = vec![ <bool>::get_ptype() ];
+    let locals = vec![ <bool>::get_type() ];
     let stmts = vec![storage_live(0), storage_live(0)];
     let p = small_program(&locals, &stmts);
     assert_ill_formed(p);
@@ -20,10 +20,7 @@ fn double_live() {
 #[test]
 fn neg_count_array() {
     let ty = array_ty(<()>::get_type(), -1);
-    let pty = ptype(ty, align(1));
-    let locals = &[
-        pty,
-    ];
+    let locals = &[ty];
 
     let stmts = &[ storage_live(0) ];
 
@@ -41,9 +38,8 @@ fn no_main() {
 #[test]
 fn too_large_local() {
     let ty = <[u8; usize::MAX/2+1]>::get_type();
-    let pty = ptype(ty, align(1));
 
-    let locals = &[pty];
+    let locals = &[ty];
     let stmts = &[];
 
     let prog = small_program(locals, stmts);
@@ -52,7 +48,7 @@ fn too_large_local() {
 
 #[test]
 fn type_mismatch() {
-    let locals = &[<i32>::get_ptype()];
+    let locals = &[<i32>::get_type()];
     let stmts = &[
         storage_live(0),
         assign(

--- a/tooling/minitest/src/tests/invalid_offset.rs
+++ b/tooling/minitest/src/tests/invalid_offset.rs
@@ -5,11 +5,10 @@ fn invalid_offset() {
     let union_ty = union_ty(&[
             (size(0), <*const i32>::get_type()),
             (size(0), <usize>::get_type()),
-        ], size(8));
-    let union_pty = ptype(union_ty, align(8));
+        ], size(8), align(8));
     let locals = &[
-        <[i32; 2]>::get_ptype(),
-        union_pty
+        <[i32; 2]>::get_type(),
+        union_ty
     ];
 
     let stmts = &[

--- a/tooling/minitest/src/tests/join.rs
+++ b/tooling/minitest/src/tests/join.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
 fn dummy_function() -> Function {
-    let locals = [<*const ()>::get_ptype()];
+    let locals = [<*const ()>::get_type()];
 
     let b0 = block!(exit());
 
@@ -11,7 +11,7 @@ fn dummy_function() -> Function {
 // Duplication of `spawn::spawn_success` for consistency.
 #[test]
 fn join_success() {
-    let locals = [ <u32>::get_ptype() ];
+    let locals = [ <u32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -30,7 +30,7 @@ fn join_success() {
 
 #[test]
 fn join_arg_count() {
-    let locals = [ <()>::get_ptype() ];
+    let locals = [ <()>::get_type() ];
 
     let b0 = block!(
         Terminator::CallIntrinsic {
@@ -50,7 +50,7 @@ fn join_arg_count() {
 
 #[test]
 fn join_arg_value() {
-    let locals = [ <()>::get_ptype() ];
+    let locals = [ <()>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -66,7 +66,7 @@ fn join_arg_value() {
 
 #[test]
 fn join_wrongreturn() {
-    let locals = [ <u32>::get_ptype() ];
+    let locals = [ <u32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -87,7 +87,7 @@ fn join_wrongreturn() {
 
 #[test]
 fn join_no_thread() {
-    let locals = [ <u32>::get_ptype() ];
+    let locals = [ <u32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),

--- a/tooling/minitest/src/tests/locks.rs
+++ b/tooling/minitest/src/tests/locks.rs
@@ -12,7 +12,7 @@ use crate::*;
 /// By making the critical section large (256 times around a loop)
 /// we get a high probability that the handover happened.
 fn lock_handover() {
-    let locals = [<()>::get_ptype(), <u32>::get_ptype()];
+    let locals = [<()>::get_type(), <u32>::get_type()];
 
     let b0 = block!(
         storage_live(1),
@@ -29,7 +29,7 @@ fn lock_handover() {
     let critical = function(Ret::Yes, 0, &locals, &[b0,b1,b2,b3,b4]);
 
 
-    let locals = [<u32>::get_ptype(), <()>::get_ptype()];
+    let locals = [<u32>::get_type(), <()>::get_type()];
     
     let b0 = block!(
         storage_live(0),
@@ -42,7 +42,7 @@ fn lock_handover() {
     let b4 = block!( exit() );
     let main = function(Ret::No, 0, &locals, &[b0,b1,b2,b3,b4]);
     
-    let locals = [<()>::get_ptype(), <*const ()>::get_ptype()];
+    let locals = [<()>::get_type(), <*const ()>::get_type()];
 
     let b0 = block!(
         call(2, &[], local(0), Some(1))
@@ -84,11 +84,11 @@ fn lock_handover() {
 /// If a handover occurs and data race detection does not synchronize the acquirer,
 /// it immediatly writing to global_1 would be a data race with the release.
 fn lock_handover_data_race() {
-    let locals = [<()>::get_ptype()];
+    let locals = [<()>::get_type()];
 
     let ptr_ty = <*const u32>::get_type();
 
-    let p_ptype = <u32>::get_ptype();
+    let p_ptype = <u32>::get_type();
     
     let b0 = block!(
         acquire(load(global::<u32>(0)), 1) 
@@ -99,7 +99,7 @@ fn lock_handover_data_race() {
     let critical = function(Ret::Yes, 0, &locals, &[b0,b1,b2,b3]);
 
 
-    let locals = [<u32>::get_ptype(), <()>::get_ptype()];
+    let locals = [<u32>::get_type(), <()>::get_type()];
     
     let b0 = block!(
         storage_live(0),
@@ -112,7 +112,7 @@ fn lock_handover_data_race() {
     let b4 = block!( exit() );
     let main = function(Ret::No, 0, &locals, &[b0,b1,b2,b3,b4]);
     
-    let locals = [<()>::get_ptype(), <*const ()>::get_ptype()];
+    let locals = [<()>::get_type(), <*const ()>::get_type()];
 
     let b0 = block!(
         call(2, &[], local(0), Some(1))
@@ -148,7 +148,7 @@ fn acquire_arg_count() {
 
 #[test]
 fn acquire_arg_value() {
-    let locals = [<()>::get_ptype()];
+    let locals = [<()>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -163,7 +163,7 @@ fn acquire_arg_value() {
 
 #[test]
 fn acquire_wrongreturn() {
-    let locals = [<u32>::get_ptype()];
+    let locals = [<u32>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -183,7 +183,7 @@ fn acquire_wrongreturn() {
 
 #[test]
 fn acquire_non_existent() {
-    let locals = [<u32>::get_ptype()];
+    let locals = [<u32>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -201,7 +201,7 @@ fn acquire_non_existent() {
 
 #[test]
 fn release_arg_count() {
-    let locals = [<()>::get_ptype()];
+    let locals = [<()>::get_type()];
 
     let b0 = block!(
         Terminator::CallIntrinsic {
@@ -220,7 +220,7 @@ fn release_arg_count() {
 
 #[test]
 fn release_arg_value() {
-    let locals = [<()>::get_ptype()];
+    let locals = [<()>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -235,7 +235,7 @@ fn release_arg_value() {
 
 #[test]
 fn release_wrongreturn() {
-    let locals = [<u32>::get_ptype()];
+    let locals = [<u32>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -255,7 +255,7 @@ fn release_wrongreturn() {
 
 #[test]
 fn release_non_existent() {
-    let locals = [<u32>::get_ptype()];
+    let locals = [<u32>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -271,7 +271,7 @@ fn release_non_existent() {
 
 #[test]
 fn release_non_owned() {
-    let locals = [<u32>::get_ptype()];
+    let locals = [<u32>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -291,7 +291,7 @@ fn release_non_owned() {
 
 #[test]
 fn create_arg_count() {
-    let locals = [<()>::get_ptype()];
+    let locals = [<()>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -311,7 +311,7 @@ fn create_arg_count() {
 
 #[test]
 fn create_wrongreturn() {
-    let locals = [<()>::get_ptype()];
+    let locals = [<()>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -338,7 +338,7 @@ fn deadlock() {
     // In such a situation both threads wait for each other and we have a deadlock.
 
     // The locals are used to store the thread ids.
-    let locals = [<u32>::get_ptype()];
+    let locals = [<u32>::get_type()];
 
     let b0 = block!( create_lock(global::<u32>(0), 1) );
     let b1 = block!( acquire(load(global::<u32>(0)), 2) );
@@ -351,7 +351,7 @@ fn deadlock() {
     let b5 = block!( exit() );
     let main = function(Ret::No, 0, &locals, &[b0, b1, b2, b3, b4, b5]);
 
-    let locals = [<()>::get_ptype(), <*const ()>::get_ptype()];
+    let locals = [<()>::get_type(), <*const ()>::get_type()];
     let b0 = block!( acquire(load(global::<u32>(0)), 1) );
     let b1 = block!( release(load(global::<u32>(0)), 2) );
     let b2 = block!( return_() );

--- a/tooling/minitest/src/tests/mod.rs
+++ b/tooling/minitest/src/tests/mod.rs
@@ -14,6 +14,7 @@ mod locks;
 mod negative_index;
 mod no_preserve_padding;
 mod no_preserve_prov;
+mod packed;
 mod print;
 mod ptr_offset;
 mod ptr_partial_overwrite;

--- a/tooling/minitest/src/tests/negative_index.rs
+++ b/tooling/minitest/src/tests/negative_index.rs
@@ -3,8 +3,8 @@ use crate::*;
 #[test]
 fn negative_index() {
     let locals = &[
-        <[(); 2]>::get_ptype(),
-        <()>::get_ptype(),
+        <[(); 2]>::get_type(),
+        <()>::get_type(),
     ];
 
     let stmts = &[

--- a/tooling/minitest/src/tests/no_preserve_padding.rs
+++ b/tooling/minitest/src/tests/no_preserve_padding.rs
@@ -20,20 +20,18 @@ fn no_preserve_padding() {
     let pair_ty = tuple_ty(&[
             (size(0), u8::get_type()),
             (size(2), u16::get_type())
-        ], size(4));
-    let pair_pty = ptype(pair_ty, align(2));
+        ], size(4), align(2));
 
     let union_ty = union_ty(&[
             (size(0), pair_ty),
             (size(0), u32::get_type()),
-        ], size(4));
-    let union_pty = ptype(union_ty, align(4));
+        ], size(4), align(4));
 
     let locals = vec![
-        union_pty,
-        pair_pty,
-        <*const u8>::get_ptype(),
-        <u8>::get_ptype(),
+        union_ty,
+        pair_ty,
+        <*const u8>::get_type(),
+        <u8>::get_type(),
     ];
 
     let stmts = vec![
@@ -66,11 +64,11 @@ fn no_preserve_padding() {
         ),
         assign(
             local(3),
-            load(deref(load(local(2)), <u8>::get_ptype())),
+            load(deref(load(local(2)), <u8>::get_type())),
         ),
     ];
 
     let p = small_program(&locals, &stmts);
     dump_program(p);
-    assert_ub(p, "load at type PlaceType { ty: Int(IntType { signed: Unsigned, size: Size(1 bytes) }), align: Align(1 bytes) } but the data in memory violates the validity invariant");
+    assert_ub(p, "load at type Int(IntType { signed: Unsigned, size: Size(1 bytes) }) but the data in memory violates the validity invariant");
 }

--- a/tooling/minitest/src/tests/no_preserve_prov.rs
+++ b/tooling/minitest/src/tests/no_preserve_prov.rs
@@ -7,13 +7,12 @@ fn no_preserve_prov() {
             (size(0), <[&i32; 1]>::get_type()),
             (size(0), <[usize; 1]>::get_type()),
             (size(0), <&i32>::get_type()),
-        ], size(8));
-    let union_pty = ptype(union_ty, align(8));
+        ], size(8), align(8));
 
     let locals = vec![
-        <i32>::get_ptype(),
-        union_pty,
-        <i32>::get_ptype(),
+        <i32>::get_type(),
+        union_ty,
+        <i32>::get_type(),
     ];
 
     let stmts = vec![
@@ -36,7 +35,7 @@ fn no_preserve_prov() {
             local(2),
             load(deref(
                 load(field(local(1), 2)),
-                <i32>::get_ptype(),
+                <i32>::get_type(),
             ))
         ),
     ];

--- a/tooling/minitest/src/tests/packed.rs
+++ b/tooling/minitest/src/tests/packed.rs
@@ -1,0 +1,51 @@
+use crate::*;
+
+fn make_packed() -> Type {
+    tuple_ty(
+        &[(size(0), <i32>::get_type())],
+        size(4),
+        align(1),
+    )
+}
+
+#[test]
+fn packed_works() {
+    let locals = [make_packed(), <i32>::get_type()];
+    let b0 = block!(
+        storage_live(0),
+        assign(
+            field(local(0), 0),
+            const_int::<i32>(0i32),
+        ),
+        storage_live(1),
+        assign(
+            local(1),
+            load(field(local(0), 0)),
+        ),
+        exit(),
+    );
+    let f = function(Ret::No, 0, &locals, &[b0]);
+    let p = program(&[f]);
+    assert_stop(p);
+}
+
+#[test]
+fn packed_is_not_aligned() {
+    let locals = [make_packed(), <&i32>::get_type()];
+    let b0 = block!(
+        storage_live(0),
+        assign(
+            field(local(0), 0),
+            const_int::<i32>(0i32),
+        ),
+        storage_live(1),
+        assign(
+            local(1),
+            addr_of(field(local(0), 0), <&i32>::get_type()),
+        ),
+        exit(),
+    );
+    let f = function(Ret::No, 0, &locals, &[b0]);
+    let p = program(&[f]);
+    assert_ub_eventually(p, 16, "taking the address of an invalid (null, misaligned, or uninhabited) place");
+}

--- a/tooling/minitest/src/tests/print.rs
+++ b/tooling/minitest/src/tests/print.rs
@@ -32,7 +32,7 @@ fn print_fail() {
 
 #[test]
 fn print_wrongreturn() {
-    let locals = [<u32>::get_ptype()];
+    let locals = [<u32>::get_type()];
 
     let b0 = block!(
         storage_live(0),

--- a/tooling/minitest/src/tests/ptr_offset.rs
+++ b/tooling/minitest/src/tests/ptr_offset.rs
@@ -2,7 +2,7 @@ use crate::*;
 
 #[test]
 fn ptr_offset_success() {
-    let locals = &[ <i32>::get_ptype(), <*const i32>::get_ptype() ];
+    let locals = &[ <i32>::get_type(), <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -34,7 +34,7 @@ fn ptr_offset_success() {
 
 #[test]
 fn ptr_offset_inbounds() {
-    let locals = &[ <i32>::get_ptype(), <*const i32>::get_ptype() ];
+    let locals = &[ <i32>::get_type(), <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -66,7 +66,7 @@ fn ptr_offset_inbounds() {
 
 #[test]
 fn ptr_offset_no_inbounds() {
-    let locals = &[ <i32>::get_ptype(), <*const i32>::get_ptype() ];
+    let locals = &[ <i32>::get_type(), <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -101,10 +101,9 @@ fn ptr_offset_overflow() {
     let union_ty = union_ty(&[
             (size(0), <usize>::get_type()),
             (size(0), <*const i32>::get_type()),
-        ], size(8));
-    let union_pty = ptype(union_ty, align(8));
+        ], size(8), align(8));
 
-    let locals = [ union_pty ];
+    let locals = [ union_ty ];
 
     let b0 = block!(
         storage_live(0),
@@ -132,7 +131,7 @@ fn ptr_offset_overflow() {
 
 #[test]
 fn ptr_offset_out_of_bounds() {
-    let locals = &[ <i32>::get_ptype(), <*const i32>::get_ptype() ];
+    let locals = &[ <i32>::get_type(), <*const i32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),

--- a/tooling/minitest/src/tests/ptr_partial_overwrite.rs
+++ b/tooling/minitest/src/tests/ptr_partial_overwrite.rs
@@ -3,9 +3,9 @@ use crate::*;
 #[test]
 fn pointer_partial_overwrite() {
     let locals = &[
-        <i32>::get_ptype(),
-        <&i32>::get_ptype(),
-        <i32>::get_ptype(),
+        <i32>::get_type(),
+        <&i32>::get_type(),
+        <i32>::get_type(),
     ];
 
     let stmts = &[
@@ -20,7 +20,7 @@ fn pointer_partial_overwrite() {
         assign( // this corrupts one u8 of the pointer, stripping its provenance
             deref(
                 addr_of(local(1), <*mut u8>::get_type()),
-                <u8>::get_ptype(),
+                <u8>::get_type(),
             ),
             const_int::<u8>(12)
         ),
@@ -28,7 +28,7 @@ fn pointer_partial_overwrite() {
             local(2),
             load(deref(
                 load(local(1)),
-                <i32>::get_ptype(),
+                <i32>::get_type(),
             ))
         )
     ];

--- a/tooling/minitest/src/tests/return_.rs
+++ b/tooling/minitest/src/tests/return_.rs
@@ -3,13 +3,13 @@ use crate::*;
 #[test]
 fn return_success() {
     let other_f = {
-        let locals = [<()>::get_ptype()];
+        let locals = [<()>::get_type()];
         let b0 = block!(return_());
 
         function(Ret::Yes, 0, &locals, &[b0])
     };
 
-    let locals = [<()>::get_ptype()];
+    let locals = [<()>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -26,13 +26,13 @@ fn return_success() {
 #[test]
 fn return_no_next() {
     let other_f = {
-        let locals = [<()>::get_ptype()];
+        let locals = [<()>::get_type()];
         let b0 = block!(return_());
 
         function(Ret::Yes, 0, &locals, &[b0])
     };
 
-    let locals = [<()>::get_ptype()];
+    let locals = [<()>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -48,7 +48,7 @@ fn return_no_next() {
 
 #[test]
 fn return_intrinsic_no_next() {
-    let locals = [<*const i32>::get_ptype()];
+    let locals = [<*const i32>::get_type()];
 
     let b0 = block!(
         storage_live(0),

--- a/tooling/minitest/src/tests/spawn.rs
+++ b/tooling/minitest/src/tests/spawn.rs
@@ -1,14 +1,14 @@
 use crate::*;
 
 fn dummy_function() -> Function {
-    let locals = [<*const ()>::get_ptype()];
+    let locals = [<*const ()>::get_type()];
     let b0 = block!(exit());
     function(Ret::No, 1, &locals, &[b0])
 }
 
 #[test]
 fn spawn_success() {
-    let locals = [ <u32>::get_ptype() ];
+    let locals = [ <u32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -40,8 +40,8 @@ fn spawn_success() {
 /// we do a trace based search it could have one. This is the reason we track synchronized threads.
 #[test]
 fn thread_spawn_spurious_race() {
-    let pp_ptype = <*const *const ()>::get_ptype(); // Pointer pointer place type.
-    let locals = [pp_ptype, <u32>::get_ptype()];
+    let pp_ptype = <*const *const ()>::get_type(); // Pointer pointer place type.
+    let locals = [pp_ptype, <u32>::get_type()];
 
     let size = const_int::<usize>(<*const ()>::get_size().bytes());
     let align = const_int::<usize>(<*const ()>::get_align().bytes());
@@ -69,7 +69,7 @@ fn thread_spawn_spurious_race() {
     let b4 = block!( exit() );
     let main = function(Ret::No, 0, &locals, &[b0,b1,b2,b3,b4]);
 
-    let locals = [<()>::get_ptype(), pp_ptype];
+    let locals = [<()>::get_type(), pp_ptype];
     let b0 = block!(
         assign(deref(load(local(1)), pp_ptype), null()),
         return_(),
@@ -104,7 +104,7 @@ fn spawn_arg_count() {
 
 #[test]
 fn spawn_arg_value() {
-    let locals = [<u32>::get_ptype()];
+    let locals = [<u32>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -127,7 +127,7 @@ fn no_args() -> Function {
 
 #[test]
 fn spawn_func_no_args() {
-    let locals = [<i32>::get_ptype()];
+    let locals = [<i32>::get_type()];
     let b0 = block!(
         storage_live(0),
         spawn(fn_ptr(1), null(), local(0), 1),
@@ -141,7 +141,7 @@ fn spawn_func_no_args() {
 
 
 fn returns() -> Function {
-    let locals = [<u32>::get_ptype(), <*const ()>::get_ptype()];
+    let locals = [<u32>::get_type(), <*const ()>::get_type()];
     let b0 = block!(
         assign(local(0), const_int::<u32>(0)),
         return_()
@@ -151,7 +151,7 @@ fn returns() -> Function {
 
 #[test]
 fn spawn_func_returns() {
-    let locals = [<i32>::get_ptype()];
+    let locals = [<i32>::get_type()];
 
     let b0 = block!(
         storage_live(0),
@@ -166,7 +166,7 @@ fn spawn_func_returns() {
 
 #[test]
 fn spawn_wrongreturn() {
-    let locals = [ <()>::get_ptype() ];
+    let locals = [ <()>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -184,7 +184,7 @@ fn spawn_wrongreturn() {
 
 #[test]
 fn spawn_data_ptr() {
-    let locals = [ <()>::get_ptype() ];
+    let locals = [ <()>::get_type() ];
 
     let b0 = block!(
         storage_live(0),
@@ -201,14 +201,14 @@ fn spawn_data_ptr() {
 }
 
 fn wrongarg() -> Function {
-    let locals = [<()>::get_ptype()];
+    let locals = [<()>::get_type()];
     let b0 = block!(exit());
     function(Ret::No, 1, &locals, &[b0])
 }
 
 #[test]
 fn spawn_wrongarg() {
-    let locals = [ <u32>::get_ptype() ];
+    let locals = [ <u32>::get_type() ];
 
     let b0 = block!(
         storage_live(0),

--- a/tooling/minitest/src/tests/too_large_alloc.rs
+++ b/tooling/minitest/src/tests/too_large_alloc.rs
@@ -2,7 +2,7 @@ use crate::*;
 
 #[test]
 fn too_large_alloc() {
-    let locals = vec![<*const usize>::get_ptype()];
+    let locals = vec![<*const usize>::get_type()];
     let b = block!(
         storage_live(0),
         allocate(const_int::<usize>(usize::MAX / 2 + 1), const_int::<usize>(1), local(0), 1),

--- a/tooling/minitest/src/tests/uninit_read.rs
+++ b/tooling/minitest/src/tests/uninit_read.rs
@@ -2,7 +2,7 @@ use crate::*;
 
 #[test]
 fn uninit_read() {
-    let locals = vec![ <bool>::get_ptype(); 2];
+    let locals = vec![ <bool>::get_type(); 2];
     let stmts = vec![
         storage_live(0),
         storage_live(1),
@@ -12,5 +12,5 @@ fn uninit_read() {
         ),
     ];
     let p = small_program(&locals, &stmts);
-    assert_ub(p, "load at type PlaceType { ty: Bool, align: Align(1 bytes) } but the data in memory violates the validity invariant");
+    assert_ub(p, "load at type Bool but the data in memory violates the validity invariant");
 }

--- a/tooling/minitest/src/tests/zst.rs
+++ b/tooling/minitest/src/tests/zst.rs
@@ -3,10 +3,7 @@ use crate::*;
 #[test]
 fn zst_array() {
     let a = array_ty(<()>::get_type(), 2);
-    let a_pty = ptype(a, align(1));
-    let locals = &[
-        a_pty,
-    ];
+    let locals = &[a];
 
     let stmts = &[
         storage_live(0),
@@ -24,11 +21,10 @@ fn zst_array() {
 
 #[test]
 fn zst_tuple() {
-    let tuple = tuple_ty(&[(size(0), <()>::get_type()); 2], size(0));
-    let tuple_pty = ptype(tuple, align(1));
+    let tuple = tuple_ty(&[(size(0), <()>::get_type()); 2], size(0), align(1));
     let locals = &[
-        tuple_pty,
-        <()>::get_ptype(),
+        tuple,
+        <()>::get_type(),
     ];
 
     let stmts = &[
@@ -50,11 +46,10 @@ fn zst_tuple2() {
     let tuple = tuple_ty(&[
         (size(0), <i8>::get_type()),
         (size(1), <()>::get_type()),
-    ], size(1));
-    let tuple_pty = ptype(tuple, align(1));
+    ], size(1), align(1));
     let locals = &[
-        tuple_pty,
-        <()>::get_ptype(),
+        tuple,
+        <()>::get_type(),
     ];
 
     let stmts = &[

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -97,6 +97,13 @@ pub fn ptr_to_ptr(v: ValueExpr, t: Type) -> ValueExpr {
     }
 }
 
+pub fn transmute(v: ValueExpr, t: Type) -> ValueExpr {
+    ValueExpr::UnOp {
+        operator: UnOp::Transmute(t),
+        operand: GcCow::new(v),
+    }
+}
+
 fn int_binop<T: TypeConv>(op: BinOpInt, l: ValueExpr, r: ValueExpr) -> ValueExpr {
     let Type::Int(t) = T::get_type() else {
         panic!("int operator received non-int type!");

--- a/tooling/miniutil/src/build/expr.rs
+++ b/tooling/miniutil/src/build/expr.rs
@@ -182,14 +182,14 @@ pub fn global<T: TypeConv>(x: u32) -> PlaceExpr {
 
     deref(
         ValueExpr::Constant(Constant::GlobalPointer(relocation), ptr_type),
-        T::get_ptype()
+        T::get_type()
     )
 }
 
-pub fn deref(operand: ValueExpr, ptype: PlaceType) -> PlaceExpr {
+pub fn deref(operand: ValueExpr, ty: Type) -> PlaceExpr {
     PlaceExpr::Deref {
         operand: GcCow::new(operand),
-        ptype,
+        ty,
     }
 }
 
@@ -212,6 +212,6 @@ pub fn zst_place() -> PlaceExpr {
     let ptr = ValueExpr::Constant(Constant::InvalidPointer(1.into()), <*const ()>::get_type());
     PlaceExpr::Deref {
         operand: GcCow::new(ptr),
-        ptype: <()>::get_ptype(),
+        ty: <()>::get_type(),
     }
 }

--- a/tooling/miniutil/src/build/function.rs
+++ b/tooling/miniutil/src/build/function.rs
@@ -29,8 +29,8 @@ pub enum Ret {
 // if ret == No,
 //   then there is no return local
 //   and _0 .. _n are the locals of the function args.
-pub fn function(ret: Ret, num_args: usize, locals: &[PlaceType], bbs: &[BasicBlock]) -> Function {
-    let mut locals: Map<LocalName, PlaceType> = locals
+pub fn function(ret: Ret, num_args: usize, locals: &[Type], bbs: &[BasicBlock]) -> Function {
+    let mut locals: Map<LocalName, Type> = locals
         .iter()
         .enumerate()
         .map(|(i, l)| {
@@ -61,7 +61,7 @@ pub fn function(ret: Ret, num_args: usize, locals: &[PlaceType], bbs: &[BasicBlo
         Ret::No => {
             // Generate a return local of type unit.
             let name = LocalName(Name::from_internal(locals.len().try_to_usize().unwrap() as _));
-            locals.try_insert(name, <()>::get_ptype()).unwrap();
+            locals.try_insert(name, <()>::get_type()).unwrap();
             name
         }
     };

--- a/tooling/miniutil/src/build/mod.rs
+++ b/tooling/miniutil/src/build/mod.rs
@@ -78,7 +78,7 @@ pub fn program(fns: &[Function]) -> Program {
 }
 
 // Generates a small program with a single basic block.
-pub fn small_program(locals: &[PlaceType], statements: &[Statement]) -> Program {
+pub fn small_program(locals: &[Type], statements: &[Statement]) -> Program {
     let b = block(statements, exit());
     let f = function(Ret::No, 0, locals, &[b]);
 

--- a/tooling/miniutil/src/build/statement.rs
+++ b/tooling/miniutil/src/build/statement.rs
@@ -48,9 +48,8 @@ pub fn call(f: u32, args: &[ArgumentExpr], ret: PlaceExpr, next: Option<u32>) ->
     }
 }
 
-pub fn by_value<T: TypeConv>(val: ValueExpr) -> ArgumentExpr {
-    let pty = T::get_ptype();
-    ArgumentExpr::ByValue(val, pty.align)
+pub fn by_value(val: ValueExpr) -> ArgumentExpr {
+    ArgumentExpr::ByValue(val)
 }
 
 pub fn in_place(arg: PlaceExpr) -> ArgumentExpr {

--- a/tooling/miniutil/src/build/ty.rs
+++ b/tooling/miniutil/src/build/ty.rs
@@ -38,18 +38,20 @@ pub fn raw_ptr_ty() -> Type {
     Type::Ptr(PtrType::Raw)
 }
 
-pub fn tuple_ty(f: &[(Size, Type)], size: Size) -> Type {
+pub fn tuple_ty(f: &[(Size, Type)], size: Size, align: Align) -> Type {
     Type::Tuple {
         fields: f.iter().copied().collect(),
         size,
+        align,
     }
 }
 
-pub fn union_ty(f: &[(Size, Type)], size: Size) -> Type {
+pub fn union_ty(f: &[(Size, Type)], size: Size, align: Align) -> Type {
     let chunks = list![(Size::ZERO, size)];
     Type::Union {
         fields: f.iter().copied().collect(),
         size,
+        align,
         chunks,
     }
 }
@@ -59,8 +61,4 @@ pub fn array_ty(elem: Type, count: impl Into<Int>) -> Type {
         elem: GcCow::new(elem),
         count: count.into(),
     }
-}
-
-pub fn ptype(ty: Type, align: Align) -> PlaceType {
-    PlaceType { ty, align }
 }

--- a/tooling/miniutil/src/build/ty_conv.rs
+++ b/tooling/miniutil/src/build/ty_conv.rs
@@ -6,27 +6,21 @@ use crate::build::*;
 /// Example usage: `let x: Type = <usize>::get_type();`
 pub trait TypeConv {
     fn get_type() -> Type;
-    fn get_align() -> Align;
 
     // Convenience methods, these should not be overridden.
     fn get_size() -> Size {
         Self::get_type().size::<DefaultTarget>()
     }
-
-    fn get_ptype() -> PlaceType {
-        PlaceType {
-            ty: Self::get_type(),
-            align: Self::get_align(),
-        }
+    fn get_align() -> Align {
+        Self::get_type().align::<DefaultTarget>()
     }
-
     fn get_layout() -> Layout {
-        Self::get_ptype().layout::<DefaultTarget>()
+        Self::get_type().layout::<DefaultTarget>()
     }
 }
 
 macro_rules! type_conv_int_impl {
-    ($ty:ty, $signed:expr, $size:expr, $align:expr) => {
+    ($ty:ty, $signed:expr, $size:expr) => {
         impl TypeConv for $ty {
             fn get_type() -> Type {
                 Type::Int(IntType {
@@ -34,36 +28,30 @@ macro_rules! type_conv_int_impl {
                     size: $size,
                 })
             }
-            fn get_align() -> Align {
-                $align
-            }
         }
     };
 }
 
-type_conv_int_impl!(u8, Unsigned, size(1), align(1));
-type_conv_int_impl!(u16, Unsigned, size(2), align(2));
-type_conv_int_impl!(u32, Unsigned, size(4), align(4));
-type_conv_int_impl!(u64, Unsigned, size(8), align(8));
-type_conv_int_impl!(u128, Unsigned, size(16), align(8));
+type_conv_int_impl!(u8, Unsigned, size(1));
+type_conv_int_impl!(u16, Unsigned, size(2));
+type_conv_int_impl!(u32, Unsigned, size(4));
+type_conv_int_impl!(u64, Unsigned, size(8));
+type_conv_int_impl!(u128, Unsigned, size(16));
 
-type_conv_int_impl!(i8, Signed, size(1), align(1));
-type_conv_int_impl!(i16, Signed, size(2), align(2));
-type_conv_int_impl!(i32, Signed, size(4), align(4));
-type_conv_int_impl!(i64, Signed, size(8), align(8));
-type_conv_int_impl!(i128, Signed, size(16), align(8));
+type_conv_int_impl!(i8, Signed, size(1));
+type_conv_int_impl!(i16, Signed, size(2));
+type_conv_int_impl!(i32, Signed, size(4));
+type_conv_int_impl!(i64, Signed, size(8));
+type_conv_int_impl!(i128, Signed, size(16));
 
 // We use `BasicMemory` to run a Program (see the `run` module),
 // hence we have to use its PTR_SIZE for `usize` and `isize`.
-type_conv_int_impl!(usize, Unsigned, DefaultTarget::PTR_SIZE, DefaultTarget::PTR_ALIGN);
-type_conv_int_impl!(isize, Signed, DefaultTarget::PTR_SIZE, DefaultTarget::PTR_ALIGN);
+type_conv_int_impl!(usize, Unsigned, DefaultTarget::PTR_SIZE);
+type_conv_int_impl!(isize, Signed, DefaultTarget::PTR_SIZE);
 
 impl<T: TypeConv> TypeConv for *const T {
     fn get_type() -> Type {
         raw_ptr_ty()
-    }
-    fn get_align() -> Align {
-        DefaultTarget::PTR_ALIGN
     }
 }
 
@@ -71,17 +59,11 @@ impl<T: TypeConv> TypeConv for *mut T {
     fn get_type() -> Type {
         raw_ptr_ty()
     }
-    fn get_align() -> Align {
-        DefaultTarget::PTR_ALIGN
-    }
 }
 
 impl<T: TypeConv> TypeConv for &T {
     fn get_type() -> Type {
         ref_ty(T::get_layout())
-    }
-    fn get_align() -> Align {
-        DefaultTarget::PTR_ALIGN
     }
 }
 
@@ -89,17 +71,11 @@ impl<T: TypeConv> TypeConv for &mut T {
     fn get_type() -> Type {
         ref_mut_ty(T::get_layout())
     }
-    fn get_align() -> Align {
-        DefaultTarget::PTR_ALIGN
-    }
 }
 
 impl TypeConv for bool {
     fn get_type() -> Type {
         bool_ty()
-    }
-    fn get_align() -> Align {
-        align(1)
     }
 }
 
@@ -107,16 +83,10 @@ impl<T: TypeConv, const N: usize> TypeConv for [T; N] {
     fn get_type() -> Type {
         array_ty(T::get_type(), N)
     }
-    fn get_align() -> Align {
-        T::get_align()
-    }
 }
 
 impl TypeConv for () {
     fn get_type() -> Type {
-        tuple_ty(&[], size(0))
-    }
-    fn get_align() -> Align {
-        align(1)
+        tuple_ty(&[], size(0), align(1))
     }
 }

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -36,8 +36,8 @@ impl FmtExpr {
 pub(super) fn fmt_place_expr(p: PlaceExpr, comptypes: &mut Vec<CompType>) -> FmtExpr {
     match p {
         PlaceExpr::Local(l) => FmtExpr::Atomic(fmt_local_name(l)),
-        PlaceExpr::Deref { operand, ptype } => {
-            let ptype = fmt_ptype(ptype, comptypes).to_string();
+        PlaceExpr::Deref { operand, ty } => {
+            let ptype = fmt_type(ty, comptypes).to_string();
             let expr = fmt_value_expr(operand.extract(), comptypes).to_string();
             FmtExpr::Atomic(format!("deref<{ptype}>({expr})"))
         }

--- a/tooling/miniutil/src/fmt/expr.rs
+++ b/tooling/miniutil/src/fmt/expr.rs
@@ -161,6 +161,10 @@ pub(super) fn fmt_value_expr(v: ValueExpr, comptypes: &mut Vec<CompType>) -> Fmt
                     let ptr_ty = fmt_ptr_type(ptr_ty).to_string();
                     FmtExpr::Atomic(format!("from_exposed<{ptr_ty}>({operand})"))
                 }
+                UnOp::Transmute(new_ty) => {
+                    let new_ty = fmt_type(new_ty, comptypes).to_string();
+                    FmtExpr::Atomic(format!("transmute<{new_ty}>({operand})"))
+                }
             }
         }
         ValueExpr::BinOp {

--- a/tooling/miniutil/src/fmt/function.rs
+++ b/tooling/miniutil/src/fmt/function.rs
@@ -44,15 +44,15 @@ fn fmt_function(
     };
 
     // Format locals
-    let mut locals: Vec<(LocalName, PlaceType)> = f.locals.iter().collect();
+    let mut locals: Vec<(LocalName, Type)> = f.locals.iter().collect();
 
     // The locals are formatted in the order of their names.
-    locals.sort_by_key(|(LocalName(name), _place_ty)| *name);
+    locals.sort_by_key(|(LocalName(name), _ty)| *name);
 
-    for (l, pty) in locals {
+    for (l, ty) in locals {
         let local = fmt_local_name(l).to_string();
-        let ptype = fmt_ptype(pty, comptypes).to_string();
-        out += &format!("  let {local}: {ptype};\n");
+        let ty = fmt_type(ty, comptypes).to_string();
+        out += &format!("  let {local}: {ty};\n");
     }
 
     // Format basic blocks
@@ -181,8 +181,8 @@ fn fmt_terminator(t: Terminator, comptypes: &mut Vec<CompType>) -> String {
             let args: Vec<_> = arguments
                 .iter()
                 .map(|arg| match arg {
-                    ArgumentExpr::ByValue(value, align) =>
-                        format!("by-value({})@align({})", fmt_value_expr(value, comptypes).to_string(), align.bytes()),
+                    ArgumentExpr::ByValue(value) =>
+                        format!("by-value({})", fmt_value_expr(value, comptypes).to_string()),
                     ArgumentExpr::InPlace(place) =>
                         format!("in-place({})", fmt_place_expr(place, comptypes).to_string()),
                 })

--- a/tooling/miniutil/src/fmt/ty.rs
+++ b/tooling/miniutil/src/fmt/ty.rs
@@ -1,11 +1,5 @@
 use super::*;
 
-pub(super) fn fmt_ptype(place_ty: PlaceType, comptypes: &mut Vec<CompType>) -> String {
-    let ty_str = fmt_type(place_ty.ty, comptypes).to_atomic_string();
-    let align = place_ty.align.bytes();
-    format!("{ty_str}@align({align})")
-}
-
 pub(super) fn fmt_type(t: Type, comptypes: &mut Vec<CompType>) -> FmtExpr {
     match t {
         Type::Int(int_ty) => FmtExpr::Atomic(fmt_int_type(int_ty)),
@@ -127,18 +121,20 @@ pub(super) fn fmt_comptypes(mut comptypes: Vec<CompType>) -> String {
 }
 
 fn fmt_comptype(i: CompTypeIndex, t: CompType, comptypes: &mut Vec<CompType>) -> String {
-    let (keyword, fields, opt_chunks, size) = match t.0 {
-        Type::Tuple { fields, size } => ("tuple", fields, None, size),
+    let (keyword, fields, opt_chunks, size, align) = match t.0 {
+        Type::Tuple { fields, size, align } => ("tuple", fields, None, size, align),
         Type::Union {
             chunks,
             fields,
             size,
-        } => ("union", fields, Some(chunks), size),
+            align,
+        } => ("union", fields, Some(chunks), size, align),
         _ => panic!("not a supported composite type!"),
     };
     let ct = fmt_comptype_index(i).to_string();
     let size = size.bytes();
-    let mut s = format!("{keyword} {ct} ({size} bytes) {{\n");
+    let align = align.bytes();
+    let mut s = format!("{keyword} {ct} ({size} bytes, aligned {align} bytes) {{\n");
     for (offset, f) in fields {
         let offset = offset.bytes();
         let ty = fmt_type(f, comptypes).to_string();


### PR DESCRIPTION
This gets rid of `PlaceType` entirely, and instead enriches `Place` values with an `aligned: bool` field. Alignment is checked at deref time, but the check is only enforced if the place gets loaded/stored.